### PR TITLE
Simplify publish

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,6 @@ machine:
 
 dependencies:
   pre:
-    - "curl http://beyondgrep.com/ack-2.14-single-file > ~/bin/ack && chmod 0755 ~/bin/ack"
     - |
       if [[ ! -e ~/.yarn/bin/yarn || $(yarn --version) != "${YARN_VERSION}" ]]; then
         echo "Download and install Yarn."

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
   "author": "Chris Sauve <chris.sauve@shopify.com>",
   "scripts": {
     "check": "yarn run lint && yarn test",
-    "deploy": "npm publish",
     "rules-status": "eslint-index lib/config/all.js  --format table",
     "rules-omitted": "eslint-index lib/config/all.js  --status omitted",
     "lint": "eslint . --max-warnings 0",

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,4 +1,0 @@
-deploy:
-  override:
-    - npm install --no-progress
-    - npm run deploy


### PR DESCRIPTION
Publish via shipit's new npm support.

Also removing ack download from the CI config (it's only necessary for shopify-codemod).