### PR TITLE
jquery-dollar-sign-reference now checks LogicalExpression values

### DIFF
--- a/lib/rules/jquery-dollar-sign-reference.js
+++ b/lib/rules/jquery-dollar-sign-reference.js
@@ -126,15 +126,34 @@ module.exports = {
       };
     }
 
+    function getValueNodes(node) {
+      var results = [];
+      if (node.type === 'LogicalExpression') {
+        results.push.apply(results, getValueNodes(node.left));
+        results.push.apply(results, getValueNodes(node.right));
+      } else if (node.type === 'ConditionalExpression') {
+        results.push.apply(results, getValueNodes(node.consequent));
+        results.push.apply(results, getValueNodes(node.alternate));
+      } else {
+        results.push(node);
+      }
+      return results;
+    }
+
     function checkForValidjQueryReference(node, left, right) {
       if (right == null) { return; }
       var isjQueryRef = isjQueryReference(left);
-      var isjQueryVal = isjQueryValue(right);
-      // console.log(right);
+      var valueNodeTypes = getValueNodes(right).map(isjQueryValue);
+      var hasDefinitejQueryValue = valueNodeTypes.some(function(nodeType) {
+        return nodeType.definite;
+      });
+      var hasRegularValue = valueNodeTypes.some(function(nodeType) {
+        return !nodeType.possible;
+      });
 
-      if (isjQueryRef && !isjQueryVal.possible) {
+      if (isjQueryRef && hasRegularValue) {
         context.report(node, 'Don’t use a $-prefixed identifier for a non-jQuery value.');
-      } else if (!isjQueryRef && isjQueryVal.definite) {
+      } else if (!isjQueryRef && hasDefinitejQueryValue) {
         context.report(node, 'Use a $-prefixed identifier for a jQuery value.');
       }
     }

--- a/tests/lib/rules/jquery-dollar-sign-reference.js
+++ b/tests/lib/rules/jquery-dollar-sign-reference.js
@@ -224,6 +224,13 @@ ruleTester.run('jquery-dollar-sign-reference', rule, {
     {code: 'var $foo = foo[$foo];'},
     {code: 'var foo = foo[bar];'},
     {code: 'var $foo = foo[bar];'},
+
+    {code: 'var $foo = $bar || $qux;'},
+    {code: 'var $foo = $bar && $qux;'},
+    {code: 'var $foo = $bar || ($qux && $baz);'},
+    {code: 'var foo = bar || qux;'},
+    {code: 'var foo = bar && quz;'},
+    {code: 'var foo = bar || (qux && baz);'},
   ],
   invalid: [
     {
@@ -574,6 +581,23 @@ ruleTester.run('jquery-dollar-sign-reference', rule, {
     {
       code: 'var $foo = foo["$foo"].size();',
       errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+
+    {
+      code: 'var $foo = bar || $baz;',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var $foo = ($bar || ($baz && qux));',
+      errors: [unexpectedDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = bar || $baz;',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
+    },
+    {
+      code: 'var foo = (bar || (baz && $qux));',
+      errors: [missingDollarError({type: 'VariableDeclarator'})],
     },
   ],
 });


### PR DESCRIPTION
## What does it do?

Flags `$`-prefix assignment mismatches within LogicalExpressions.  e.g.,

The following code is flagged because the receiving var `$foo` could accept a value from the non-$-prefixed `qux` var.

```js
const $foo = $bar || qux;
```

The following code is flagged because the receiving var `foo` could accept a value from the $-prefixed `$bar` var.

```js
const foo = $bar || qux;
```

-----

## How does it do it?
Updates `checkForValidjQueryReference` to dig into the `right` side of an assignment to find all possible assignment sources.  The list of source nodes is checked for `$`/regular types, and a reworded version of the original logic is applied to the results.


Fixes #2