### PR TITLE
Eslint upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,7 @@
 
 ### Removed
 - Removed `eslint-find-rules` package ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+
+# Pre-15.1.1 Changelog
+
+Changes were originally tracked in Shopify's [JavaScript monorepo](https://github.com/Shopify/javascript/blob/f10bf7ddbdae07370cfe7c94617c450257731552/CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [15.2.0] - 2017-03-06
+### Changed
+- `eslint` upgrade to `3.17.x`
+
 ## [15.1.2] - 2017-02-23
 ### Fixed
 - `jquery-dollar-sign-reference` now checks assignments from `LogicalExpression` / `BinaryExpression`

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-cli": "6.x",
     "babel-core": "6.x",
     "babel-preset-shopify": "15.0.1",
-    "eslint": "3.10.x",
+    "eslint": "3.17.x",
     "eslint-index": "1.2.x",
     "eslint-plugin-shopify": "file:.",
     "isparta": "4.x",
@@ -48,7 +48,7 @@
     "mocha": "3.x"
   },
   "peerDependencies": {
-    "eslint": "3.10.x"
+    "eslint": "3.17.x"
   },
   "dependencies": {
     "babel-eslint": "7.1.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,7 +14,7 @@ acorn@^3.0.4:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
 
-acorn@^4.0.1:
+acorn@^4.0.1, acorn@4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.4.tgz#17a8d6a7a6c4ef538b814ec9abac2779293bf30a"
 
@@ -1453,9 +1453,9 @@ eslint@^3.11.1:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
-eslint@3.10.x:
-  version "3.10.2"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.10.2.tgz#c9a10e8bf6e9d65651204778c503341f1eac3ce7"
+eslint@3.17.x:
+  version "3.17.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.17.0.tgz#e2704b09c5bae9fb49ee8bafeea3832c7257d498"
   dependencies:
     babel-code-frame "^6.16.0"
     chalk "^1.1.3"
@@ -1463,12 +1463,12 @@ eslint@3.10.x:
     debug "^2.1.1"
     doctrine "^1.2.2"
     escope "^3.6.0"
-    espree "^3.3.1"
+    espree "^3.4.0"
     estraverse "^4.2.0"
     esutils "^2.0.2"
     file-entry-cache "^2.0.0"
     glob "^7.0.3"
-    globals "^9.2.0"
+    globals "^9.14.0"
     ignore "^3.2.0"
     imurmurhash "^0.1.4"
     inquirer "^0.12.0"
@@ -1487,7 +1487,7 @@ eslint@3.10.x:
     require-uncached "^1.0.2"
     shelljs "^0.7.5"
     strip-bom "^3.0.0"
-    strip-json-comments "~1.0.1"
+    strip-json-comments "~2.0.1"
     table "^3.7.8"
     text-table "~0.2.0"
     user-home "^2.0.0"
@@ -1497,6 +1497,13 @@ espree@^3.1.3, espree@^3.3.1:
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.3.2.tgz#dbf3fadeb4ecb4d4778303e50103b3d36c88b89c"
   dependencies:
     acorn "^4.0.1"
+    acorn-jsx "^3.0.0"
+
+espree@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.4.0.tgz#41656fa5628e042878025ef467e78f125cb86e1d"
+  dependencies:
+    acorn "4.0.4"
     acorn-jsx "^3.0.0"
 
 esprima@^2.1.0, esprima@^2.6.0, esprima@^2.7.1, esprima@2.7.x:
@@ -1765,7 +1772,7 @@ glob@7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.0.0, globals@^9.14.0, globals@^9.2.0:
+globals@^9.0.0, globals@^9.14.0:
   version "9.14.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.14.0.tgz#8859936af0038741263053b39d0e76ca241e4034"
 
@@ -2997,7 +3004,7 @@ strip-bom@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
-strip-json-comments@~1.0.1, strip-json-comments@~1.0.4:
+strip-json-comments@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-1.0.4.tgz#1e15fbcac97d3ee99bf2d73b4c656b082bbafb91"
 


### PR DESCRIPTION
Bumps the `eslint` version.  This is to get `shopify/shopify` / `sewing-kit` / `eslint-plugin-shopify` all on compatible eslint dependencies.