### PR TITLE
relax minor version requirement of peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-shopify",
-  "version": "15.2.1",
+  "version": "15.3.0",
   "description": "Shopify’s ESLint rules and configs.",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-shopify",
-  "version": "15.2.0",
+  "version": "15.2.1",
   "description": "Shopify’s ESLint rules and configs.",
   "keywords": [
     "eslint",
@@ -48,7 +48,7 @@
     "mocha": "3.x"
   },
   "peerDependencies": {
-    "eslint": "3.17.x"
+    "eslint": "3.x"
   },
   "dependencies": {
     "babel-eslint": "7.1.x",


### PR DESCRIPTION
Unless there is a reason to specify a minor version of a peer dependency, the extra range reduces duplication for consumers of the library