### PR TITLE
Fix prefer-destructuring errors

### DIFF
--- a/tests/lib/rules/binary-assignment-parens.js
+++ b/tests/lib/rules/binary-assignment-parens.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/binary-assignment-parens');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/class-property-semi.js
+++ b/tests/lib/rules/class-property-semi.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/class-property-semi');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/jquery-dollar-sign-reference.js
+++ b/tests/lib/rules/jquery-dollar-sign-reference.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/jquery-dollar-sign-reference');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/no-fully-static-classes.js
+++ b/tests/lib/rules/no-fully-static-classes.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/no-fully-static-classes');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/no-useless-computed-properties.js
+++ b/tests/lib/rules/no-useless-computed-properties.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/no-useless-computed-properties');
 require('babel-eslint');
 

--- a/tests/lib/rules/prefer-class-properties.js
+++ b/tests/lib/rules/prefer-class-properties.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/prefer-class-properties');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/prefer-early-return.js
+++ b/tests/lib/rules/prefer-early-return.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/prefer-early-return');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/prefer-twine.js
+++ b/tests/lib/rules/prefer-twine.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/prefer-twine');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/restrict-full-import.js
+++ b/tests/lib/rules/restrict-full-import.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/restrict-full-import');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/sinon-no-restricted-features.js
+++ b/tests/lib/rules/sinon-no-restricted-features.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/sinon-no-restricted-features');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/sinon-prefer-meaningful-assertions.js
+++ b/tests/lib/rules/sinon-prefer-meaningful-assertions.js
@@ -1,4 +1,4 @@
-const RuleTester = require('eslint').RuleTester;
+const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/sinon-prefer-meaningful-assertions');
 
 const ruleTester = new RuleTester();


### PR DESCRIPTION
CI builds on the [individual commits](https://github.com/Shopify/eslint-plugin-shopify/commits/master) for my last two PR are green. The builds on their respective PR's were green as well. 

When I created & push up new tags for a `v16.0.0` release, CI failed because of the newly added `prefer-destructuring` rule. I rebased out the `v16.0.0` comment and had to locally nuke my `node_modules` dir to reproduce the errors.

Finding it very strange that CI only picked up the issue after the tag got pushed.