### PR TITLE
Update README to specify eslint version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,12 @@ Shopify’s ESLint rules and configs.
 
 You'll first need to install [ESLint](http://eslint.org):
 
+> **Note** `eslint-plugin-shopify` has not yet been updated to work with the latest version of `eslint`. Please make sure you use v3.19.0
+
 **With Yarn**
 
 ```bash
-yarn add --dev eslint
+yarn add --dev eslint@3.19.0
 ```
 
 **With npm**


### PR DESCRIPTION
I got stuck on running the linter because, by default, `yarn add ...` installs the latest version of a plugin. We need to specify `3.19.0`