### PR TITLE
Add argsIgnorePattern for no-unused-vars

### DIFF
--- a/lib/config/rules/variables.js
+++ b/lib/config/rules/variables.js
@@ -22,7 +22,7 @@ module.exports = {
   // Disallow use of undefined variable
   'no-undefined': 'error',
   // Disallow declaration of variables that are not used in the code
-  'no-unused-vars': 'warn',
+  'no-unused-vars': ['warn', { "argsIgnorePattern": "^_" }],
   // Disallow use of variables before they are defined
   'no-use-before-define': ['error', 'nofunc'],
 };


### PR DESCRIPTION
Changes this rule to allow unused arguments in functions, assuming that
the variable is prefixed with an underscore.

For example:

Under the current rules this is not permitted:

      const myMap = new Map([
        ['a', 1],
        ['b', 2],
        ['c', 3],
        ['d', 4],
      ]);

      Array.from(myMap, ([_key, value]) => value);
      > [1, 2, 3, 4]

or similarity

      Array.from(myMap, ([_, value]) => value);

And this is what would be preferred by the config

      Array.from(myMap, (entryPair) => entryPair[1]);

Oddly enough this is also allowed by the current config

      Array.from(myMap, ([, value]) => value);

Which is arguably much worse.

Ignoring unused positional arguments is quite common in functional
styles, which is what is encouraged.