### PR TITLE
Upgrade eslint to 4.7.0 & update rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,40 @@
 # Changelog
 
 ## [Unreleased]
+
+## [17.1.0] - 2017-09-18
+
+### Added
+* New rules ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
+  - `import/no-anonymous-default-export`
+  - `jsx-a11y/anchor-is-valid`
+  - `no-buffer-constructor`
+  - `node/no-extraneous-import` (disabled)
+  - `node/no-extraneous-require`
+  - `for-direction`
+  - `getter-return`
+  - `react/boolean-prop-naming` (disabled)
+  - `react/default-props-match-prop-types`
+  - `react/no-redundant-should-component-update`
+  - `react/no-typos`
+  - `react/no-unused-state`
+  - `react/jsx-closing-tag-location`
+  - `array-bracket-newline`
+  - `array-element-newline`
+  - `function-paren-newline`
+  - `padding-line-between-statements` (disabled)
+  - `semi-style`
+  - `switch-colon-spacing`
+
+
+### Changed
+- Updated dependencies ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
+  - `eslint`
+  - `babel-eslint`
+  - `eslint-plugin-import`
+  - `eslint-plugin-jsx-a11y`
+  - `eslint-plugin-node`
+  - `eslint-plugin-react`
 - `jquery-dollar-sign-reference` no longer flags assignments from `await` expressions
 
 ## [17.0.0] - 2017-08-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-## [17.1.0] - 2017-09-18
+## [17.1.0] - 2017-09-19
 
 ### Added
 * New rules ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
@@ -36,6 +36,9 @@
   - `eslint-plugin-node`
   - `eslint-plugin-react`
 - `jquery-dollar-sign-reference` no longer flags assignments from `await` expressions
+
+### Removed
+- `jsx-a11y/href-no-hash` replaced with `jsx-a11y/anchor-is-valid`
 
 ## [17.0.0] - 2017-08-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@
   - `react/no-typos`
   - `react/no-unused-state`
   - `react/jsx-closing-tag-location`
-  - `array-bracket-newline`
-  - `array-element-newline`
+  - `array-bracket-newline` (disabled)
+  - `array-element-newline` (disabled)
   - `function-paren-newline`
   - `padding-line-between-statements` (disabled)
   - `semi-style`

--- a/lib/config/rules/import.js
+++ b/lib/config/rules/import.js
@@ -75,4 +75,6 @@ module.exports = {
   'import/max-dependencies': 'off',
   // Forbid unassigned imports
   'import/no-unassigned-import': 'off',
+  // Forbid anonymous values as default exports
+  'import/no-anonymous-default-export': 'off' // FEEDBACK
 };

--- a/lib/config/rules/import.js
+++ b/lib/config/rules/import.js
@@ -75,6 +75,6 @@ module.exports = {
   'import/max-dependencies': 'off',
   // Forbid unassigned imports
   'import/no-unassigned-import': 'off',
-  // Forbid anonymous values as default exports
-  'import/no-anonymous-default-export': 'off' // FEEDBACK
+  // Forbid anonymous values as default exports <FEEDBACK>
+  'import/no-anonymous-default-export': 'off',
 };

--- a/lib/config/rules/import.js
+++ b/lib/config/rules/import.js
@@ -75,6 +75,6 @@ module.exports = {
   'import/max-dependencies': 'off',
   // Forbid unassigned imports
   'import/no-unassigned-import': 'off',
-  // Forbid anonymous values as default exports <FEEDBACK>
-  'import/no-anonymous-default-export': 'off',
+  // Forbid anonymous values as default exports
+  'import/no-anonymous-default-export': 'error',
 };

--- a/lib/config/rules/jsx-a11y.js
+++ b/lib/config/rules/jsx-a11y.js
@@ -7,7 +7,7 @@ module.exports = {
   'jsx-a11y/alt-text': 'error',
   // Enforce all anchors to contain accessible content.
   'jsx-a11y/anchor-has-content': 'error',
-  // Enforce all anchors are valid, navigable elements. <FEEDBACK>
+  // Enforce all anchors are valid, navigable elements.
   'jsx-a11y/anchor-is-valid': 'error',
   // Enforce elements with aria-activedescendant are tabbable.
   'jsx-a11y/aria-activedescendant-has-tabindex': 'error',

--- a/lib/config/rules/jsx-a11y.js
+++ b/lib/config/rules/jsx-a11y.js
@@ -7,6 +7,8 @@ module.exports = {
   'jsx-a11y/alt-text': 'error',
   // Enforce all anchors to contain accessible content.
   'jsx-a11y/anchor-has-content': 'error',
+  // Enforce all anchors are valid, navigable elements.
+  'jsx-a11y/anchor-is-valid': 'error', // FEEDBACK
   // Enforce elements with aria-activedescendant are tabbable.
   'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
   // Enforce all aria-* props are valid.

--- a/lib/config/rules/jsx-a11y.js
+++ b/lib/config/rules/jsx-a11y.js
@@ -7,8 +7,8 @@ module.exports = {
   'jsx-a11y/alt-text': 'error',
   // Enforce all anchors to contain accessible content.
   'jsx-a11y/anchor-has-content': 'error',
-  // Enforce all anchors are valid, navigable elements.
-  'jsx-a11y/anchor-is-valid': 'error', // FEEDBACK
+  // Enforce all anchors are valid, navigable elements. <FEEDBACK>
+  'jsx-a11y/anchor-is-valid': 'error',
   // Enforce elements with aria-activedescendant are tabbable.
   'jsx-a11y/aria-activedescendant-has-tabindex': 'error',
   // Enforce all aria-* props are valid.

--- a/lib/config/rules/jsx-a11y.js
+++ b/lib/config/rules/jsx-a11y.js
@@ -23,8 +23,6 @@ module.exports = {
   'jsx-a11y/click-events-have-key-events': 'error',
   // Enforce heading (h1, h2, etc) elements contain accessible content.
   'jsx-a11y/heading-has-content': 'error',
-  // Enforce an anchor element's href prop value is not just #.
-  'jsx-a11y/href-no-hash': 'error',
   // Enforce <html> element has lang prop.
   'jsx-a11y/html-has-lang': 'error',
   // Enforce iframe elements have a title attribute.

--- a/lib/config/rules/node.js
+++ b/lib/config/rules/node.js
@@ -7,6 +7,8 @@ module.exports = {
   'global-require': 'off',
   // Enforces error handling in callbacks
   'handle-callback-err': ['warn', '^.*(e|E)rr(or)?$'],
+  // disallow use of the Buffer() constructor
+  'no-buffer-constructor': 'off', // FEEDBACK
   // Disallow mixing regular variable and require declarations
   'no-mixed-requires': 'off',
   // Disallow use of new operator with the require function

--- a/lib/config/rules/node.js
+++ b/lib/config/rules/node.js
@@ -8,7 +8,7 @@ module.exports = {
   // Enforces error handling in callbacks
   'handle-callback-err': ['warn', '^.*(e|E)rr(or)?$'],
   // disallow use of the Buffer() constructor
-  'no-buffer-constructor': 'off', // FEEDBACK
+  'no-buffer-constructor': 'error',
   // Disallow mixing regular variable and require declarations
   'no-mixed-requires': 'off',
   // Disallow use of new operator with the require function
@@ -24,9 +24,10 @@ module.exports = {
   // Disallow use of synchronous methods
   'no-sync': 'off',
   // disallow import declarations of extraneous packages
-  'node/no-extraneous-import': 'off', // FEEDBACK
+  // defer to import/no-extraneous-dependencies
+  'node/no-extraneous-import': 'off',
   // disallow require() expressions of extraneous packages
-  'node/no-extraneous-require': 'off', // FEEDBACK
+  'node/no-extraneous-require': 'error',
   // Enforce either module.exports or exports.
   'node/exports-style': ['warn', 'module.exports'],
   // Disallow deprecated API.

--- a/lib/config/rules/node.js
+++ b/lib/config/rules/node.js
@@ -21,6 +21,10 @@ module.exports = {
   'no-restricted-modules': 'off',
   // Disallow use of synchronous methods
   'no-sync': 'off',
+  // disallow import declarations of extraneous packages
+  'node/no-extraneous-import': 'off', // FEEDBACK
+  // disallow require() expressions of extraneous packages
+  'node/no-extraneous-require': 'off', // FEEDBACK
   // Enforce either module.exports or exports.
   'node/exports-style': ['warn', 'module.exports'],
   // Disallow deprecated API.

--- a/lib/config/rules/possible-errors.js
+++ b/lib/config/rules/possible-errors.js
@@ -3,8 +3,8 @@
 module.exports = {
   // enforce “for” loop update clause moving the counter in the right direction.
   'for-direction': 'error',
-  // enforce return statements in getters <FEEDBACK>
-  'getter-return': ['error', {'allowImplicit': true}],
+  // enforce return statements in getters
+  'getter-return': ['error', {allowImplicit: true}],
   // Disallow await inside of loops
   'no-await-in-loop': 'off',
   // Disallow comparing against -0

--- a/lib/config/rules/possible-errors.js
+++ b/lib/config/rules/possible-errors.js
@@ -1,10 +1,10 @@
 // see http://eslint.org/docs/rules/#possible-errors
 
 module.exports = {
-  // 	enforce “for” loop update clause moving the counter in the right direction.
-  'for-direction': 'off', // FEEDBACK
-  // enforce return statements in getters
-  'getter-return': 'off', // FEEDBACK
+  // enforce “for” loop update clause moving the counter in the right direction.
+  'for-direction': 'error',
+  // enforce return statements in getters <FEEDBACK>
+  'getter-return': ['error', {'allowImplicit': true}],
   // Disallow await inside of loops
   'no-await-in-loop': 'off',
   // Disallow comparing against -0

--- a/lib/config/rules/possible-errors.js
+++ b/lib/config/rules/possible-errors.js
@@ -1,6 +1,10 @@
 // see http://eslint.org/docs/rules/#possible-errors
 
 module.exports = {
+  // 	enforce “for” loop update clause moving the counter in the right direction.
+  'for-direction': 'off', // FEEDBACK
+  // enforce return statements in getters
+  'getter-return': 'off', // FEEDBACK
   // Disallow await inside of loops
   'no-await-in-loop': 'off',
   // Disallow comparing against -0

--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -1,12 +1,12 @@
 module.exports = {
   // General
 
-  // Enforces consistent naming for boolean props
-  'react/boolean-prop-naming': 'off', // FEEDBACK
+  // Enforces consistent naming for boolean props <FEEDBACK>
+  'react/boolean-prop-naming': 'off',
   // Prevent missing displayName in a React component definition
   'react/display-name': ['warn', {ignoreTranspilerName: false}],
-  // Prevent extraneous defaultProps on components
-  'react/default-props-match-prop-types': 'off', // FEEDBACK
+  // Prevent extraneous defaultProps on components <FEEDBACK>
+  'react/default-props-match-prop-types': 'error',
   // Forbid certain props on Components
   'react/forbid-component-props': 'off',
   // Forbid certain elements e.g. forbid all <div /> and use <Box /> instead
@@ -37,8 +37,8 @@ module.exports = {
   'react/no-is-mounted': 'error',
   // Prevent multiple component definition per file
   'react/no-multi-comp': 'off',
-  // Prevent usage of shouldComponentUpdate when extending React.PureComponent
-  'react/no-redundant-should-component-update': 'off', // FEEDBACK
+  // Prevent usage of shouldComponentUpdate when extending React.PureComponent <FEEDBACK>
+  'react/no-redundant-should-component-update': 'error',
   // Prevent usage of the return value of React.render
   'react/no-render-return-value': 'error',
   // Prevent usage of setState
@@ -89,7 +89,7 @@ module.exports = {
   // Validate closing bracket location in JSX
   'react/jsx-closing-bracket-location': ['warn', {location: 'tag-aligned'}],
   // Validate closing tag location in JSX
-  'react/jsx-closing-tag-location': 'off', // FEEDBACK
+  'react/jsx-closing-tag-location': 'error',
   // Enforce or disallow spaces inside of curly braces in JSX attributes
   'react/jsx-curly-spacing': ['warn', 'never', {allowMultiline: true}],
   // Enforce or disallow spaces around equal signs in JSX attributes

--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -89,7 +89,7 @@ module.exports = {
   // Validate closing bracket location in JSX
   'react/jsx-closing-bracket-location': ['warn', {location: 'tag-aligned'}],
   // Validate closing tag location in JSX
-  'react/jsx-closing-tag-location': ['error', {location: 'line-aligned'}],
+  'react/jsx-closing-tag-location': 'error',
   // Enforce or disallow spaces inside of curly braces in JSX attributes
   'react/jsx-curly-spacing': ['warn', 'never', {allowMultiline: true}],
   // Enforce or disallow spaces around equal signs in JSX attributes

--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -1,8 +1,12 @@
 module.exports = {
   // General
 
+  // Enforces consistent naming for boolean props
+  'react/boolean-prop-naming': 'off', // FEEDBACK
   // Prevent missing displayName in a React component definition
   'react/display-name': ['warn', {ignoreTranspilerName: false}],
+  // Prevent extraneous defaultProps on components
+  'react/default-props-match-prop-types': 'off', // FEEDBACK
   // Forbid certain props on Components
   'react/forbid-component-props': 'off',
   // Forbid certain elements e.g. forbid all <div /> and use <Box /> instead
@@ -33,10 +37,14 @@ module.exports = {
   'react/no-is-mounted': 'error',
   // Prevent multiple component definition per file
   'react/no-multi-comp': 'off',
+  // Prevent usage of shouldComponentUpdate when extending React.PureComponent
+  'react/no-redundant-should-component-update': 'off', // FEEDBACK
   // Prevent usage of the return value of React.render
   'react/no-render-return-value': 'error',
   // Prevent usage of setState
   'react/no-set-state': 'off',
+  // Prevent common casing typos
+  'react/no-typos': 'error',
   // Prevent using string references in ref attribute.
   'react/no-string-refs': 'warn',
   // Prevent invalid characters from appearing in markup
@@ -45,6 +53,8 @@ module.exports = {
   'react/no-unknown-property': 'off',
   // Prevent definitions of unused prop types
   'react/no-unused-prop-types': 'warn',
+  // Attempts to discover all state fields in a React component and warn if any of them are never read.
+  'react/no-unused-state': 'error',
   // Prevent usage of setState in componentWillUpdate
   'react/no-will-update-set-state': 'error',
   // Enforce ES5 or ES6 class for React Components
@@ -78,6 +88,8 @@ module.exports = {
   'react/jsx-boolean-value': 'warn',
   // Validate closing bracket location in JSX
   'react/jsx-closing-bracket-location': ['warn', {location: 'tag-aligned'}],
+  // Validate closing tag location in JSX
+  'react/jsx-closing-tag-location': 'off', // FEEDBACK
   // Enforce or disallow spaces inside of curly braces in JSX attributes
   'react/jsx-curly-spacing': ['warn', 'never', {allowMultiline: true}],
   // Enforce or disallow spaces around equal signs in JSX attributes

--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -1,11 +1,11 @@
 module.exports = {
   // General
 
-  // Enforces consistent naming for boolean props <FEEDBACK>
+  // Enforces consistent naming for boolean props
   'react/boolean-prop-naming': 'off',
   // Prevent missing displayName in a React component definition
   'react/display-name': ['warn', {ignoreTranspilerName: false}],
-  // Prevent extraneous defaultProps on components <FEEDBACK>
+  // Prevent extraneous defaultProps on components
   'react/default-props-match-prop-types': 'error',
   // Forbid certain props on Components
   'react/forbid-component-props': 'off',
@@ -37,7 +37,7 @@ module.exports = {
   'react/no-is-mounted': 'error',
   // Prevent multiple component definition per file
   'react/no-multi-comp': 'off',
-  // Prevent usage of shouldComponentUpdate when extending React.PureComponent <FEEDBACK>
+  // Prevent usage of shouldComponentUpdate when extending React.PureComponent
   'react/no-redundant-should-component-update': 'error',
   // Prevent usage of the return value of React.render
   'react/no-render-return-value': 'error',
@@ -89,7 +89,7 @@ module.exports = {
   // Validate closing bracket location in JSX
   'react/jsx-closing-bracket-location': ['warn', {location: 'tag-aligned'}],
   // Validate closing tag location in JSX
-  'react/jsx-closing-tag-location': 'error',
+  'react/jsx-closing-tag-location': ['error', {location: 'line-aligned'}],
   // Enforce or disallow spaces inside of curly braces in JSX attributes
   'react/jsx-curly-spacing': ['warn', 'never', {allowMultiline: true}],
   // Enforce or disallow spaces around equal signs in JSX attributes

--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -1,8 +1,12 @@
 // see http://eslint.org/docs/rules/#stylistic-issues
 
 module.exports = {
+  // enforce linebreaks after opening and before closing array brackets
+  'array-bracket-newline': 'off', // FEEDBACK
   // Enforce spacing inside array brackets
   'array-bracket-spacing': ['warn', 'never'],
+  // enforce line breaks after each array element
+  'array-element-newline': 'off', // FEEDBACK
   // Disallow or enforce spaces inside of single line blocks
   'block-spacing': ['warn', 'always'],
   // Enforce one true brace style
@@ -29,6 +33,8 @@ module.exports = {
   'func-names': 'off',
   // Enforces use of function declarations or expressions
   'func-style': ['warn', 'declaration'],
+  // enforce consistent line breaks inside function parentheses
+  'function-paren-newline': 'off', // FEEDBACK
   // Blacklist certain identifiers to prevent them being used
   'id-blacklist': 'off',
   // This option enforces minimum and maximum identifier lengths (variable names, property names etc.)
@@ -129,6 +135,8 @@ module.exports = {
   'operator-linebreak': ['warn', 'after', {overrides: {'?': 'before', ':': 'before'}}],
   // Enforce padding within blocks
   'padded-blocks': 'off',
+  // require or disallow padding lines between statements
+  'padding-line-between-statements': 'off', // FEEDBACK
   // Require quotes around object literal property names
   'quote-props': ['warn', 'as-needed'],
   // Specify whether backticks, double or single quotes should be used
@@ -137,6 +145,8 @@ module.exports = {
   'require-jsdoc': 'off',
   // Enforce spacing before and after semicolons
   'semi-spacing': ['warn', {before: false, after: true}],
+  // enforce location of semicolons
+  'semi-style': 'off', // FEEDBACK
   // Require or disallow use of semicolons instead of ASI
   'semi': ['warn', 'always'],
   // Requires object keys to be sorted
@@ -155,6 +165,8 @@ module.exports = {
   'space-unary-ops': ['warn', {words: true, nonwords: false}],
   // Require or disallow a space immediately following the // or /* in a comment
   'spaced-comment': ['warn', 'always', {markers: ['=']}],
+  // enforce spacing around colons of switch statements
+  'switch-colon-spacing': 'off', // FEEDBACK
   // Require or disallow spacing between template tags and their literals
   'template-tag-spacing': ['error', 'never'],
   // Require or disallow the Unicode BOM

--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -1,12 +1,12 @@
 // see http://eslint.org/docs/rules/#stylistic-issues
 
 module.exports = {
-  // enforce linebreaks after opening and before closing array brackets <FEEDBACK>
-  'array-bracket-newline': ['error', {'multiline': true}],
+  // enforce linebreaks after opening and before closing array brackets
+  'array-bracket-newline': ['error', {multiline: true}],
   // Enforce spacing inside array brackets
   'array-bracket-spacing': ['warn', 'never'],
-  // enforce line breaks after each array element <FEEDBACK>
-  'array-element-newline': ['error', {'multiline': true}],
+  // enforce line breaks after each array element
+  'array-element-newline': ['error', {multiline: true}],
   // Disallow or enforce spaces inside of single line blocks
   'block-spacing': ['warn', 'always'],
   // Enforce one true brace style
@@ -33,7 +33,7 @@ module.exports = {
   'func-names': 'off',
   // Enforces use of function declarations or expressions
   'func-style': ['warn', 'declaration'],
-  // enforce consistent line breaks inside function parentheses <FEEDBACK>
+  // enforce consistent line breaks inside function parentheses
   'function-paren-newline': ['error', 'multiline'],
   // Blacklist certain identifiers to prevent them being used
   'id-blacklist': 'off',
@@ -135,7 +135,7 @@ module.exports = {
   'operator-linebreak': ['warn', 'after', {overrides: {'?': 'before', ':': 'before'}}],
   // Enforce padding within blocks
   'padded-blocks': 'off',
-  // require or disallow padding lines between statements <FEEDBACK>
+  // require or disallow padding lines between statements
   'padding-line-between-statements': 'off',
   // Require quotes around object literal property names
   'quote-props': ['warn', 'as-needed'],

--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -2,11 +2,11 @@
 
 module.exports = {
   // enforce linebreaks after opening and before closing array brackets
-  'array-bracket-newline': ['error', {multiline: true}],
+  'array-bracket-newline': 'off',
   // Enforce spacing inside array brackets
   'array-bracket-spacing': ['warn', 'never'],
   // enforce line breaks after each array element
-  'array-element-newline': ['error', {multiline: true}],
+  'array-element-newline': 'off',
   // Disallow or enforce spaces inside of single line blocks
   'block-spacing': ['warn', 'always'],
   // Enforce one true brace style

--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -34,7 +34,7 @@ module.exports = {
   // Enforces use of function declarations or expressions
   'func-style': ['warn', 'declaration'],
   // enforce consistent line breaks inside function parentheses
-  'function-paren-newline': ['error', 'multiline'],
+  'function-paren-newline': ['error', 'consistent'],
   // Blacklist certain identifiers to prevent them being used
   'id-blacklist': 'off',
   // This option enforces minimum and maximum identifier lengths (variable names, property names etc.)

--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -1,12 +1,12 @@
 // see http://eslint.org/docs/rules/#stylistic-issues
 
 module.exports = {
-  // enforce linebreaks after opening and before closing array brackets
-  'array-bracket-newline': 'off', // FEEDBACK
+  // enforce linebreaks after opening and before closing array brackets <FEEDBACK>
+  'array-bracket-newline': ['error', {'multiline': true}],
   // Enforce spacing inside array brackets
   'array-bracket-spacing': ['warn', 'never'],
-  // enforce line breaks after each array element
-  'array-element-newline': 'off', // FEEDBACK
+  // enforce line breaks after each array element <FEEDBACK>
+  'array-element-newline': ['error', {'multiline': true}],
   // Disallow or enforce spaces inside of single line blocks
   'block-spacing': ['warn', 'always'],
   // Enforce one true brace style
@@ -33,8 +33,8 @@ module.exports = {
   'func-names': 'off',
   // Enforces use of function declarations or expressions
   'func-style': ['warn', 'declaration'],
-  // enforce consistent line breaks inside function parentheses
-  'function-paren-newline': 'off', // FEEDBACK
+  // enforce consistent line breaks inside function parentheses <FEEDBACK>
+  'function-paren-newline': ['error', 'multiline'],
   // Blacklist certain identifiers to prevent them being used
   'id-blacklist': 'off',
   // This option enforces minimum and maximum identifier lengths (variable names, property names etc.)
@@ -135,8 +135,8 @@ module.exports = {
   'operator-linebreak': ['warn', 'after', {overrides: {'?': 'before', ':': 'before'}}],
   // Enforce padding within blocks
   'padded-blocks': 'off',
-  // require or disallow padding lines between statements
-  'padding-line-between-statements': 'off', // FEEDBACK
+  // require or disallow padding lines between statements <FEEDBACK>
+  'padding-line-between-statements': 'off',
   // Require quotes around object literal property names
   'quote-props': ['warn', 'as-needed'],
   // Specify whether backticks, double or single quotes should be used
@@ -146,7 +146,7 @@ module.exports = {
   // Enforce spacing before and after semicolons
   'semi-spacing': ['warn', {before: false, after: true}],
   // enforce location of semicolons
-  'semi-style': 'off', // FEEDBACK
+  'semi-style': ['error', 'last'],
   // Require or disallow use of semicolons instead of ASI
   'semi': ['warn', 'always'],
   // Requires object keys to be sorted
@@ -166,7 +166,7 @@ module.exports = {
   // Require or disallow a space immediately following the // or /* in a comment
   'spaced-comment': ['warn', 'always', {markers: ['=']}],
   // enforce spacing around colons of switch statements
-  'switch-colon-spacing': 'off', // FEEDBACK
+  'switch-colon-spacing': ['error', {'after': true, 'before': false}],
   // Require or disallow spacing between template tags and their literals
   'template-tag-spacing': ['error', 'never'],
   // Require or disallow the Unicode BOM

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint": "<5 >=4.3.0"
   },
   "dependencies": {
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^8.0.0",
     "eslint-plugin-ava": "^4.2.1",
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-chai-expect": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-lodash": "^2.4.4",
     "eslint-plugin-mocha": "^4.11.0",
-    "eslint-plugin-node": "^4.2.3",
+    "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-react": "^7.2.0",
     "eslint-plugin-sort-class-members": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-dom": "^15.6.1"
   },
   "peerDependencies": {
-    "eslint": "<5 >=4.3.0"
+    "eslint": "<5 >=4.7.0"
   },
   "dependencies": {
     "babel-eslint": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-node": "^5.1.1",
     "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-react": "^7.2.0",
+    "eslint-plugin-react": "^7.3.0",
     "eslint-plugin-sort-class-members": "^1.2.0",
     "merge": "^1.2.0"
   }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-chai-expect": "^1.1.1",
     "eslint-plugin-flowtype": "^2.32.1",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-jsx-a11y": "^5.0.1",
+    "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-lodash": "^2.4.4",
     "eslint-plugin-mocha": "^4.11.0",
     "eslint-plugin-node": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "eslint-plugin-babel": "^4.1.2",
     "eslint-plugin-chai-expect": "^1.1.1",
     "eslint-plugin-flowtype": "^2.32.1",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-jsx-a11y": "^6.0.2",
     "eslint-plugin-lodash": "^2.4.4",
     "eslint-plugin-mocha": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
     "babel-preset-shopify": "^16.1.0",
-    "eslint": "^4.3.0",
+    "eslint": "^4.7.0",
     "eslint-index": "^1.4.0",
     "eslint-plugin-shopify": "file:.",
     "isparta": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-cli": "^6.24.1",
     "babel-core": "^6.25.0",
     "babel-preset-shopify": "^16.1.0",
-    "eslint": "^4.7.0",
+    "eslint": "^4.7.1",
     "eslint-index": "^1.4.0",
     "eslint-plugin-shopify": "file:.",
     "isparta": "^4.0.0",
@@ -55,7 +55,7 @@
     "react-dom": "^15.6.1"
   },
   "peerDependencies": {
-    "eslint": "<5 >=4.7.0"
+    "eslint": "<5 >=4.7.1"
   },
   "dependencies": {
     "babel-eslint": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1543,9 +1543,9 @@ eslint@^4.2.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
-eslint@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.7.0.tgz#d35fc07c472520be3de85b3da11e99c576afd515"
+eslint@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.7.1.tgz#849804136953ebe366782f9f8611e2cbd1b54681"
   dependencies:
     ajv "^5.2.0"
     babel-code-frame "^6.22.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1443,16 +1443,6 @@ eslint-plugin-mocha@^4.11.0:
   dependencies:
     ramda "^0.24.1"
 
-eslint-plugin-node@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz#c04390ab8dbcbb6887174023d6f3a72769e63b97"
-  dependencies:
-    ignore "^3.0.11"
-    minimatch "^3.0.2"
-    object-assign "^4.0.1"
-    resolve "^1.1.7"
-    semver "5.3.0"
-
 eslint-plugin-node@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.1.1.tgz#a7ed956e780c22aef6afd1116005acd82f26eac6"
@@ -1474,6 +1464,15 @@ eslint-plugin-react@^7.2.0:
     has "^1.0.1"
     jsx-ast-utils "^2.0.0"
 
+eslint-plugin-react@^7.3.0:
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.3.0.tgz#ca9368da36f733fbdc05718ae4e91f778f38e344"
+  dependencies:
+    doctrine "^2.0.0"
+    has "^1.0.1"
+    jsx-ast-utils "^2.0.0"
+    prop-types "^15.5.10"
+
 "eslint-plugin-shopify@file:./.":
   version "17.0.0"
   dependencies:
@@ -1486,7 +1485,7 @@ eslint-plugin-react@^7.2.0:
     eslint-plugin-jsx-a11y "^6.0.2"
     eslint-plugin-lodash "^2.4.4"
     eslint-plugin-mocha "^4.11.0"
-    eslint-plugin-node "^4.2.3"
+    eslint-plugin-node "^5.1.1"
     eslint-plugin-promise "^3.5.0"
     eslint-plugin-react "^7.2.0"
     eslint-plugin-sort-class-members "^1.2.0"
@@ -1966,7 +1965,7 @@ iconv-lite@^0.4.17, iconv-lite@~0.4.13:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
 
-ignore@^3.0.11, ignore@^3.3.3:
+ignore@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
@@ -3035,7 +3034,7 @@ resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.3:
+resolve@^1.2.0, resolve@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1419,18 +1419,6 @@ eslint-plugin-import@^2.2.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-jsx-a11y@^5.0.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-5.1.1.tgz#5c96bb5186ca14e94db1095ff59b3e2bd94069b1"
-  dependencies:
-    aria-query "^0.7.0"
-    array-includes "^3.0.3"
-    ast-types-flow "0.0.7"
-    axobject-query "^0.1.0"
-    damerau-levenshtein "^1.0.0"
-    emoji-regex "^6.1.0"
-    jsx-ast-utils "^1.4.0"
-
 eslint-plugin-jsx-a11y@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.2.tgz#659277a758b036c305a7e4a13057c301cd3be73f"
@@ -1465,6 +1453,15 @@ eslint-plugin-node@^4.2.3:
     resolve "^1.1.7"
     semver "5.3.0"
 
+eslint-plugin-node@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-5.1.1.tgz#a7ed956e780c22aef6afd1116005acd82f26eac6"
+  dependencies:
+    ignore "^3.3.3"
+    minimatch "^3.0.4"
+    resolve "^1.3.3"
+    semver "5.3.0"
+
 eslint-plugin-promise@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
@@ -1486,7 +1483,7 @@ eslint-plugin-react@^7.2.0:
     eslint-plugin-chai-expect "^1.1.1"
     eslint-plugin-flowtype "^2.32.1"
     eslint-plugin-import "^2.2.0"
-    eslint-plugin-jsx-a11y "^5.0.1"
+    eslint-plugin-jsx-a11y "^6.0.2"
     eslint-plugin-lodash "^2.4.4"
     eslint-plugin-mocha "^4.11.0"
     eslint-plugin-node "^4.2.3"
@@ -3038,7 +3035,7 @@ resolve@1.1.x:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.7, resolve@^1.2.0:
+resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.3:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -254,15 +254,6 @@ babel-core@^6.1.4, babel-core@^6.24.1, babel-core@^6.25.0:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-eslint@^7.2.3:
-  version "7.2.3"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-traverse "^6.23.1"
-    babel-types "^6.23.0"
-    babylon "^6.17.0"
-
 babel-eslint@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.0.tgz#ce06f385bdfb5b6d7e603f06222f891abd14c240"
@@ -881,7 +872,7 @@ babel-traverse@7.0.0-beta.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
+babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
@@ -903,7 +894,7 @@ babel-types@7.0.0-beta.0:
     lodash "^4.2.0"
     to-fast-properties "^2.0.0"
 
-babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0:
+babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
@@ -916,7 +907,7 @@ babylon@7.0.0-beta.22:
   version "7.0.0-beta.22"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.22.tgz#74f0ad82ed7c7c3cfeab74cf684f815104161b65"
 
-babylon@^6.17.0, babylon@^6.17.2:
+babylon@^6.17.2:
   version "6.17.4"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -1440,6 +1431,18 @@ eslint-plugin-jsx-a11y@^5.0.1:
     emoji-regex "^6.1.0"
     jsx-ast-utils "^1.4.0"
 
+eslint-plugin-jsx-a11y@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.2.tgz#659277a758b036c305a7e4a13057c301cd3be73f"
+  dependencies:
+    aria-query "^0.7.0"
+    array-includes "^3.0.3"
+    ast-types-flow "0.0.7"
+    axobject-query "^0.1.0"
+    damerau-levenshtein "^1.0.0"
+    emoji-regex "^6.1.0"
+    jsx-ast-utils "^1.4.0"
+
 eslint-plugin-lodash@^2.4.4:
   version "2.4.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-2.4.4.tgz#ecc7b216fdd487df2f542734ea1215203cb563ec"
@@ -1477,7 +1480,7 @@ eslint-plugin-react@^7.2.0:
 "eslint-plugin-shopify@file:./.":
   version "17.0.0"
   dependencies:
-    babel-eslint "^7.2.3"
+    babel-eslint "^8.0.0"
     eslint-plugin-ava "^4.2.1"
     eslint-plugin-babel "^4.1.2"
     eslint-plugin-chai-expect "^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,6 +214,14 @@ babel-cli@^6.24.1:
   optionalDependencies:
     chokidar "^1.6.1"
 
+babel-code-frame@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz#418a7b5f3f7dc9a4670e61b1158b4c5661bec98d"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -254,6 +262,15 @@ babel-eslint@^7.2.3:
     babel-traverse "^6.23.1"
     babel-types "^6.23.0"
     babylon "^6.17.0"
+
+babel-eslint@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.0.tgz#ce06f385bdfb5b6d7e603f06222f891abd14c240"
+  dependencies:
+    babel-code-frame "7.0.0-beta.0"
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
 
 babel-generator@^6.25.0:
   version "6.25.0"
@@ -310,6 +327,15 @@ babel-helper-explode-assignable-expression@^6.24.1:
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
 
+babel-helper-function-name@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz#d1b6779b647e5c5c31ebeb05e13b998e4d352d56"
+  dependencies:
+    babel-helper-get-function-arity "7.0.0-beta.0"
+    babel-template "7.0.0-beta.0"
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
@@ -319,6 +345,12 @@ babel-helper-function-name@^6.24.1:
     babel-template "^6.24.1"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
+
+babel-helper-get-function-arity@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz#9d1ab7213bb5efe1ef1638a8ea1489969b5a8b6e"
+  dependencies:
+    babel-types "7.0.0-beta.0"
 
 babel-helper-get-function-arity@^6.24.1:
   version "6.24.1"
@@ -376,6 +408,10 @@ babel-helpers@^6.24.1:
   dependencies:
     babel-runtime "^6.22.0"
     babel-template "^6.24.1"
+
+babel-messages@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-7.0.0-beta.0.tgz#6df01296e49fc8fbd0637394326a167f36da817b"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -812,6 +848,15 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-template@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-7.0.0-beta.0.tgz#85083cf9e4395d5e48bf5154d7a8d6991cafecfb"
+  dependencies:
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
+    lodash "^4.2.0"
+
 babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.7.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -820,6 +865,20 @@ babel-template@^6.24.1, babel-template@^6.25.0, babel-template@^6.7.0:
     babel-traverse "^6.25.0"
     babel-types "^6.25.0"
     babylon "^6.17.2"
+    lodash "^4.2.0"
+
+babel-traverse@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz#da14be9b762f62a2f060db464eaafdd8cd072a41"
+  dependencies:
+    babel-code-frame "7.0.0-beta.0"
+    babel-helper-function-name "7.0.0-beta.0"
+    babel-messages "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
     lodash "^4.2.0"
 
 babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
@@ -836,6 +895,14 @@ babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
+babel-types@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-7.0.0-beta.0.tgz#eb8b6e556470e6dcc4aef982d79ad229469b5169"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
@@ -844,6 +911,10 @@ babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25
     esutils "^2.0.2"
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
+
+babylon@7.0.0-beta.22:
+  version "7.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.22.tgz#74f0ad82ed7c7c3cfeab74cf684f815104161b65"
 
 babylon@^6.17.0, babylon@^6.17.2:
   version "6.17.4"
@@ -1141,6 +1212,12 @@ debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.8:
   dependencies:
     ms "2.0.0"
 
+debug@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.0.1.tgz#0564c612b521dc92d9f2988f0549e34f9c98db64"
+  dependencies:
+    ms "2.0.0"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1397,8 +1474,8 @@ eslint-plugin-react@^7.2.0:
     has "^1.0.1"
     jsx-ast-utils "^2.0.0"
 
-"eslint-plugin-shopify@file:.":
-  version "17.0.0-1"
+"eslint-plugin-shopify@file:./.":
+  version "17.0.0"
   dependencies:
     babel-eslint "^7.2.3"
     eslint-plugin-ava "^4.2.1"
@@ -1772,6 +1849,10 @@ global@^4.3.0:
   dependencies:
     min-document "^2.19.0"
     process "~0.5.1"
+
+globals@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.1.0.tgz#4425a1881be0d336b4a823a82a7be725d5dd987c"
 
 globals@^9.0.0, globals@^9.17.0:
   version "9.18.0"
@@ -3225,6 +3306,10 @@ tmp@^0.0.31:
 to-fast-properties@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 tough-cookie@~2.3.0:
   version "2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1022,6 +1022,14 @@ chalk@^2.0.0, chalk@^2.0.1:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+chalk@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  dependencies:
+    ansi-styles "^3.1.0"
+    escape-string-regexp "^1.0.5"
+    supports-color "^4.0.0"
+
 chalk@~0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
@@ -1404,7 +1412,7 @@ eslint-plugin-flowtype@^2.32.1:
   dependencies:
     lodash "^4.15.0"
 
-eslint-plugin-import@^2.2.0, eslint-plugin-import@^2.7.0:
+eslint-plugin-import@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"
   dependencies:
@@ -1473,7 +1481,7 @@ eslint-plugin-react@^7.3.0:
     eslint-plugin-babel "^4.1.2"
     eslint-plugin-chai-expect "^1.1.1"
     eslint-plugin-flowtype "^2.32.1"
-    eslint-plugin-import "^2.2.0"
+    eslint-plugin-import "^2.7.0"
     eslint-plugin-jsx-a11y "^6.0.2"
     eslint-plugin-lodash "^2.4.4"
     eslint-plugin-mocha "^4.11.0"
@@ -1494,7 +1502,7 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^4.2.0, eslint@^4.3.0:
+eslint@^4.2.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.4.0.tgz#a3e153e704b64f78290ef03592494eaba228d3bc"
   dependencies:
@@ -1535,9 +1543,58 @@ eslint@^4.2.0, eslint@^4.3.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
+eslint@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.7.0.tgz#d35fc07c472520be3de85b3da11e99c576afd515"
+  dependencies:
+    ajv "^5.2.0"
+    babel-code-frame "^6.22.0"
+    chalk "^2.1.0"
+    concat-stream "^1.6.0"
+    cross-spawn "^5.1.0"
+    debug "^3.0.1"
+    doctrine "^2.0.0"
+    eslint-scope "^3.7.1"
+    espree "^3.5.1"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^9.17.0"
+    ignore "^3.3.3"
+    imurmurhash "^0.1.4"
+    inquirer "^3.0.6"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.9.1"
+    json-stable-stringify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.4"
+    minimatch "^3.0.2"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    pluralize "^7.0.0"
+    progress "^2.0.0"
+    require-uncached "^1.0.3"
+    semver "^5.3.0"
+    strip-ansi "^4.0.0"
+    strip-json-comments "~2.0.1"
+    table "^4.0.1"
+    text-table "~0.2.0"
+
 espree@^3.1.3, espree@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.0.tgz#98358625bdd055861ea27e2867ea729faf463d8d"
+  dependencies:
+    acorn "^5.1.1"
+    acorn-jsx "^3.0.0"
+
+espree@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-3.5.1.tgz#0c988b8ab46db53100a1954ae4ba995ddd27d87e"
   dependencies:
     acorn "^5.1.1"
     acorn-jsx "^3.0.0"
@@ -2762,6 +2819,10 @@ pkg-up@^2.0.0:
 pluralize@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-4.0.0.tgz#59b708c1c0190a2f692f1c7618c446b052fd1762"
+
+pluralize@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
 
 prelude-ls@~1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1404,7 +1404,7 @@ eslint-plugin-flowtype@^2.32.1:
   dependencies:
     lodash "^4.15.0"
 
-eslint-plugin-import@^2.2.0:
+eslint-plugin-import@^2.2.0, eslint-plugin-import@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz#21de33380b9efb55f5ef6d2e210ec0e07e7fa69f"
   dependencies:
@@ -1456,14 +1456,6 @@ eslint-plugin-promise@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
 
-eslint-plugin-react@^7.2.0:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.2.1.tgz#c2673526ed6571b08c69c5f453d03f5f13e8ddbe"
-  dependencies:
-    doctrine "^2.0.0"
-    has "^1.0.1"
-    jsx-ast-utils "^2.0.0"
-
 eslint-plugin-react@^7.3.0:
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.3.0.tgz#ca9368da36f733fbdc05718ae4e91f778f38e344"
@@ -1487,7 +1479,7 @@ eslint-plugin-react@^7.3.0:
     eslint-plugin-mocha "^4.11.0"
     eslint-plugin-node "^5.1.1"
     eslint-plugin-promise "^3.5.0"
-    eslint-plugin-react "^7.2.0"
+    eslint-plugin-react "^7.3.0"
     eslint-plugin-sort-class-members "^1.2.0"
     merge "^1.2.0"
 


### PR DESCRIPTION
* Updated eslint to `4.7.0`
* Added missing rules from previous eslint releases 
* Updated `out of date` plugins as per [david-dm listing](https://david-dm.org/Shopify/eslint-plugin-shopify)

Rules descriptions tagged with `<FEEDBACK>` could use some discussion/feedback. 