### PR TITLE
lines-around-directive deprecated since ESLint 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 * `space-before-function-paren` now uses `asyncArrow` option (eg. `async () => {}`)
-
+* `lines-around-directive` was deprecated in ESLint `v4.0.0`.
 ## [17.1.0] - 2017-09-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 * `space-before-function-paren` now uses `asyncArrow` option (eg. `async () => {}`)
 * `lines-around-directive` was deprecated in ESLint `v4.0.0`.
+* Enable `padding-line-between-statements` for directives
 ## [17.1.0] - 2017-09-19
 
 ### Added

--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -134,7 +134,11 @@ module.exports = {
   // Enforce padding within blocks
   'padded-blocks': 'off',
   // require or disallow padding lines between statements
-  'padding-line-between-statements': 'off',
+  'padding-line-between-statements': [
+    'error',
+    {blankLine: 'always', prev: 'directive', next: '*'},
+    {blankLine: 'any', prev: 'directive', next: 'directive'},
+  ],
   // Require quotes around object literal property names
   'quote-props': ['warn', 'as-needed'],
   // Specify whether backticks, double or single quotes should be used

--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -59,8 +59,6 @@ module.exports = {
   'linebreak-style': 'off',
   // Enforces empty lines around comments
   'lines-around-comment': ['warn', {beforeBlockComment: true}],
-  // Require or disallow newlines around directives
-  'lines-around-directive': ['warn', 'always'],
   // Enforce position of line comments
   'line-comment-position': ['warn', {position: 'above'}],
   // Enforce a maximum file length


### PR DESCRIPTION
[lines-around-directive](https://eslint.org/docs/rules/lines-around-directive) has been deprecated as per their rule docs. I didn't/don't see it explicitly listed in their changelog. It's been replaced with replaced by the [`padding-line-between-statements`](https://eslint.org/docs/rules/padding-line-between-statements) rule, which we have [disabled](https://github.com/Shopify/eslint-plugin-shopify/blob/27de727770f287c22f053bda7364d91e225a2157/lib/config/rules/stylistic-issues.js#L139). 
