### PR TITLE
Remove pre and post version hook script

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,7 @@
     "lint": "eslint . --max-warnings 0",
     "test": "NODE_PATH=$NODE_PATH:./transforms:./tests mocha 'tests/**/*.js' --reporter spec --compilers js:babel-core/register",
     "test:watch": "yarn test -- --watch --reporter min",
-    "test:cover": "babel-node node_modules/.bin/isparta cover --report text --report html _mocha -- --reporter spec --recursive tests/",
-    "preversion": "yarn run check",
-    "postversion": "git push --follow-tags"
+    "test:cover": "babel-node node_modules/.bin/isparta cover --report text --report html _mocha -- --reporter spec --recursive tests/"
   },
   "license": "MIT",
   "babel": {


### PR DESCRIPTION
This PR removes the `preversion` and  `postversion` script. 

@kaelig recently added support for beta releases on shipit. When running 
```
yarn version --new-version x.x.x-beta.x
```

The `postversion` script fails when creating a new beta tag.
```
info New version: 17.2.0-beta.3
$ git push --follow-tags
fatal: The current branch typescript-config has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin typescript-config
``` 

I have a feeling moving forward, we'll be doing more beta releases as we explore new tools. I think it's best we remove this. 

If you have an improvement/fix for the previous approach, I'm open to suggestions.  