### PR TITLE
Replace all warns with errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## [Unreleased]
 
 ### Changed
+* Replace all `warn` with `error`
 * `space-before-function-paren` now uses `asyncArrow` option (eg. `async () => {}`)
 * `lines-around-directive` was deprecated in ESLint `v4.0.0`.
 * Enable `padding-line-between-statements` for directives
+
 ## [17.1.0] - 2017-09-19
 
 ### Added

--- a/lib/config/esnext.js
+++ b/lib/config/esnext.js
@@ -38,7 +38,7 @@ module.exports = {
     require('./rules/import'),
     {
       // default params
-      'no-param-reassign': 'warn',
+      'no-param-reassign': 'error',
       // Rules override by the Babel plugin
       'new-cap': 'off',
       'no-await-in-loop': 'off',

--- a/lib/config/jquery.js
+++ b/lib/config/jquery.js
@@ -8,6 +8,6 @@ module.exports = {
   ],
 
   rules: {
-    'shopify/jquery-dollar-sign-reference': 'warn',
+    'shopify/jquery-dollar-sign-reference': 'error',
   },
 };

--- a/lib/config/mocha.js
+++ b/lib/config/mocha.js
@@ -15,7 +15,7 @@ module.exports = {
     require('./rules/mocha'),
     require('./rules/chai-expect'),
     {
-      'shopify/sinon-prefer-meaningful-assertions': 'warn',
+      'shopify/sinon-prefer-meaningful-assertions': 'error',
       // Chai expect syntax produces unused expression warnings
       'no-unused-expressions': 'off',
       // Chai expect syntax can have long chained calls

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -27,7 +27,7 @@ module.exports = {
     require('./rules/jsx-a11y'),
     {
       // Not using `this` is fine in some lifecycle hooks
-      'class-methods-use-this': ['warn', {
+      'class-methods-use-this': ['error', {
         exceptMethods: [
           'render',
           'getChildContext',

--- a/lib/config/rules/ava.js
+++ b/lib/config/rules/ava.js
@@ -4,9 +4,9 @@ module.exports = {
   // Enforce passing correct arguments to assertions.
   'ava/assertion-arguments': 'error',
   // Limit the number of assertions in a test.
-  'ava/max-asserts': ['warn', 5],
+  'ava/max-asserts': ['error', 5],
   // Ensure no test.cb() is used.
-  'ava/no-cb-test': 'warn',
+  'ava/no-cb-test': 'error',
   // Ensure that async tests use await
   'ava/no-async-fn-without-await': 'off',
   // Ensure tests do not have duplicate modifiers.
@@ -18,9 +18,9 @@ module.exports = {
   // Ensure t.end() is only called inside test.cb().
   'ava/no-invalid-end': 'error',
   // Ensure no test.only() are present.
-  'ava/no-only-test': 'warn',
+  'ava/no-only-test': 'error',
   // Ensure no tests are nested.
-  'ava/no-nested-tests': 'warn',
+  'ava/no-nested-tests': 'error',
   // Ensure no assertions are skipped.
   'ava/no-skip-assert': 'error',
   // Ensure no tests are skipped.
@@ -28,13 +28,13 @@ module.exports = {
   // Ensure t.end() is the last statement executed.
   'ava/no-statement-after-end': 'error',
   // Ensure test.todo() is not given an implementation function.
-  'ava/no-todo-implementation': 'warn',
+  'ava/no-todo-implementation': 'error',
   // Ensure no test.todo() is used.
-  'ava/no-todo-test': 'warn',
+  'ava/no-todo-test': 'error',
   // Prevent the use of unknown test modifiers.
   'ava/no-unknown-modifiers': 'error',
   // Prefer using async/await instead of returning a Promise.
-  'ava/prefer-async-await': 'warn',
+  'ava/prefer-async-await': 'error',
   // Allow only use of the asserts that have no power-assert alternative.
   'ava/prefer-power-assert': 'off',
   // Ensure callback tests are explicitly ended.
@@ -44,9 +44,9 @@ module.exports = {
   // Prevent the incorrect use of t.
   'ava/use-t-well': 'error',
   // Ensure test functions use t as their parameter.
-  'ava/use-t': 'warn',
+  'ava/use-t': 'error',
   // Ensure that AVA is imported with test as the variable name.
-  'ava/use-test': 'warn',
+  'ava/use-test': 'error',
   // Ensure that t.true()/t.false() are used instead of t.truthy()/t.falsy().
-  'ava/use-true-false': 'warn',
+  'ava/use-true-false': 'error',
 };

--- a/lib/config/rules/babel.js
+++ b/lib/config/rules/babel.js
@@ -5,7 +5,7 @@ module.exports = {
   // Ignores capitalized decorators (@Decorator)
   'babel/new-cap': ['error', {newIsCap: true, capIsNew: false}],
   // doesn't complain about export x from "mod"; or export * as x from "mod";
-  'babel/object-curly-spacing': ['warn', 'never'],
+  'babel/object-curly-spacing': ['error', 'never'],
   // doesn't fail when inside class properties
   'babel/no-invalid-this': 'error',
   // Rule to flag missing semicolons

--- a/lib/config/rules/best-practices.js
+++ b/lib/config/rules/best-practices.js
@@ -6,37 +6,37 @@ module.exports = {
   // Enforces return statements in callbacks of array's methods
   'array-callback-return': 'error',
   // Treat var statements as if they were block scoped
-  'block-scoped-var': 'warn',
+  'block-scoped-var': 'error',
   // Enforce that class methods utilize this
-  'class-methods-use-this': 'warn',
+  'class-methods-use-this': 'error',
   // Specify the maximum cyclomatic complexity allowed in a program
   'complexity': 'off',
   // Require return statements to either always or never specify values
-  'consistent-return': 'warn',
+  'consistent-return': 'error',
   // Specify curly brace conventions for all control statements
-  'curly': ['warn', 'all'],
+  'curly': ['error', 'all'],
   // Require default case in switch statements
   'default-case': 'off',
   // Encourages use of dot notation whenever possible
-  'dot-notation': ['warn', {allowKeywords: true}],
+  'dot-notation': ['error', {allowKeywords: true}],
   // Enforces consistent newlines before or after dots
-  'dot-location': ['warn', 'property'],
+  'dot-location': ['error', 'property'],
   // Require the use of === and !==
   'eqeqeq': ['error', 'allow-null'],
   // Make sure for-in loops have an if statement
-  'guard-for-in': 'warn',
+  'guard-for-in': 'error',
   // Disallow the use of alert, confirm, and prompt
-  'no-alert': 'warn',
+  'no-alert': 'error',
   // disallow lexical declarations in case clauses
   'no-case-declarations': 'error',
   // Disallow use of arguments.caller or arguments.callee
   'no-caller': 'error',
   // Disallow division operators explicitly at beginning of regular expression
-  'no-div-regex': 'warn',
+  'no-div-regex': 'error',
   // Disallow else after a return in an if
   'no-else-return': 'off',
   // Disallow use of empty functions
-  'no-empty-function': 'warn',
+  'no-empty-function': 'error',
   // Disallow use of empty destructuring patterns
   'no-empty-pattern': 'error',
   // Disallow comparisons to null without a type-checking operator
@@ -46,19 +46,19 @@ module.exports = {
   // Disallow adding to native types
   'no-extend-native': 'error',
   // Disallow unnecessary function binding
-  'no-extra-bind': 'warn',
+  'no-extra-bind': 'error',
   // Disallow unnecessary labels
   'no-extra-label': 'error',
   // Disallow fallthrough of case statements
   'no-fallthrough': 'error',
   // Disallow the use of leading or trailing decimal points in numeric literals
-  'no-floating-decimal': 'warn',
+  'no-floating-decimal': 'error',
   // Disallow reassignments of native objects
   'no-global-assign': 'error',
   // Disallow the type conversions with shorter notations
-  'no-implicit-coercion': 'warn',
+  'no-implicit-coercion': 'error',
   // Disallow var and named functions in global scope
-  'no-implicit-globals': 'warn',
+  'no-implicit-globals': 'error',
   // Disallow use of eval()-like methods
   'no-implied-eval': 'error',
   // Disallow this keywords outside of classes or class-like objects
@@ -68,13 +68,13 @@ module.exports = {
   // Disallow use of labeled statements
   'no-labels': 'error',
   // Disallow unnecessary nested blocks
-  'no-lone-blocks': 'warn',
+  'no-lone-blocks': 'error',
   // Disallow creation of functions within loops
   'no-loop-func': 'error',
   // Disallow the use of magic numbers
   'no-magic-numbers': 'off',
   // Disallow use of multiple spaces
-  'no-multi-spaces': 'warn',
+  'no-multi-spaces': 'error',
   // Disallow use of multiline strings
   'no-multi-str': 'off',
   // Disallow use of new operator for Function object
@@ -82,12 +82,12 @@ module.exports = {
   // Disallows creating new instances of String, Number, and Boolean
   'no-new-wrappers': 'error',
   // Disallow use of new operator when not part of the assignment or comparison
-  'no-new': 'warn',
+  'no-new': 'error',
   // Disallow use of octal escape sequences in string literals,
   // such as var foo = "Copyright \251";
   'no-octal-escape': 'error',
   // Disallow use of octal literals
-  'no-octal': 'warn',
+  'no-octal': 'error',
   // Allow reassignment of function parameters
   'no-param-reassign': 'off',
   // Disallow use of process.env
@@ -109,19 +109,19 @@ module.exports = {
   // Disallow comparisons where both sides are exactly the same
   'no-self-compare': 'error',
   // Disallow use of comma operator
-  'no-sequences': 'warn',
+  'no-sequences': 'error',
   // Restrict what can be thrown as an exception
-  'no-throw-literal': 'warn',
+  'no-throw-literal': 'error',
   // Disallow unmodified conditions of loops
   'no-unmodified-loop-condition': 'error',
   // Disallow usage of expressions in statement position
-  'no-unused-expressions': 'warn',
+  'no-unused-expressions': 'error',
   // Disallow unused labels
   'no-unused-labels': 'error',
   // Disallow unnecessary .call() and .apply()
   'no-useless-call': 'error',
   // Disallow unnecessary concatenation of literals or template literals
-  'no-useless-concat': 'warn',
+  'no-useless-concat': 'error',
   // Disallow unnecessary usage of escape character
   'no-useless-escape': 'error',
   // Disallow redundant return statements
@@ -129,7 +129,7 @@ module.exports = {
   // Disallow use of void operator
   'no-void': 'error',
   // Disallow usage of configurable warning terms in comments
-  'no-warning-comments': 'warn',
+  'no-warning-comments': 'error',
   // Disallow use of the with statement
   'no-with': 'error',
   // Require using Error objects as Promise rejection reasons
@@ -141,7 +141,7 @@ module.exports = {
   // Requires to declare all vars on top of their containing scope
   'vars-on-top': 'off',
   // Require immediate function invocation to be wrapped in parentheses
-  'wrap-iife': ['warn', 'inside'],
+  'wrap-iife': ['error', 'inside'],
   // Require or disallow Yoda conditions
-  'yoda': ['warn', 'never'],
+  'yoda': ['error', 'never'],
 };

--- a/lib/config/rules/chai-expect.js
+++ b/lib/config/rules/chai-expect.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   // Prevent using comparisons in the expect() argument.
-  'chai-expect/no-inner-compare': 'warn',
+  'chai-expect/no-inner-compare': 'error',
   // Prevent calling expect(...) without an assertion like .to.be.ok.
   'chai-expect/missing-assertion': 'error',
   // Prevent calling to.be.ok and other assertion properties as functions.

--- a/lib/config/rules/ecmascript-6.js
+++ b/lib/config/rules/ecmascript-6.js
@@ -4,15 +4,15 @@ module.exports = {
   // Require braces in arrow function body
   'arrow-body-style': 'off',
   // Require parens in arrow function arguments
-  'arrow-parens': ['warn', 'always'],
+  'arrow-parens': ['error', 'always'],
   // Require space before/after arrow function's arrow
-  'arrow-spacing': ['warn', {before: true, after: true}],
+  'arrow-spacing': ['error', {before: true, after: true}],
   // Verify super() callings in constructors
   'constructor-super': 'error',
   // Enforce the spacing around the * in generator functions
-  'generator-star-spacing': ['warn', 'after'],
+  'generator-star-spacing': ['error', 'after'],
   // Disallow modifying variables of class declarations
-  'no-class-assign': 'warn',
+  'no-class-assign': 'error',
   // Disallow arrow functions where they could be confused with comparisons
   'no-confusing-arrow': ['error', {allowParens: true}],
   // Disallow modifying variables that are declared using const
@@ -28,17 +28,17 @@ module.exports = {
   // Disallow unnecessary computed property keys in object literals
   'no-useless-computed-key': 'off',
   // Disallow unnecessary constructor
-  'no-useless-constructor': 'warn',
+  'no-useless-constructor': 'error',
   // Disallow renaming import, export, and destructured assignments to the same name
   'no-useless-rename': 'error',
   // Require let or const instead of var
   'no-var': 'error',
   // Require method and property shorthand syntax for object literals
-  'object-shorthand': ['warn', 'always', {avoidQuotes: true}],
+  'object-shorthand': ['error', 'always', {avoidQuotes: true}],
   // Suggest using arrow functions as callbacks
   'prefer-arrow-callback': ['error', {allowNamedFunctions: true}],
   // Suggest using of const declaration for variables that are never modified after declared
-  'prefer-const': 'warn',
+  'prefer-const': 'error',
   // Require destructuring from arrays and/or objects
   'prefer-destructuring': 'off',
   // Disallow parseInt() in favor of binary, octal, and hexadecimal literals
@@ -50,17 +50,17 @@ module.exports = {
   // Suggest using Reflect methods where applicable
   'prefer-reflect': 'off',
   // Suggest using template literals instead of strings concatenation
-  'prefer-template': 'warn',
+  'prefer-template': 'error',
   // Enforce spacing between rest and spread operators and their expressions
-  'rest-spread-spacing': ['warn', 'never'],
+  'rest-spread-spacing': ['error', 'never'],
   // Disallow generator functions that do not have yield
   'require-yield': 'error',
   // Sort import declarations within module
   'sort-imports': 'off',
   // Require symbol descriptions
-  'symbol-description': 'warn',
+  'symbol-description': 'error',
   // Enforce spacing around embedded expressions of template strings
-  'template-curly-spacing': ['warn', 'never'],
+  'template-curly-spacing': ['error', 'never'],
   // Enforce spacing around the * in yield* expressions
-  'yield-star-spacing': ['warn', {before: false, after: true}],
+  'yield-star-spacing': ['error', {before: false, after: true}],
 };

--- a/lib/config/rules/flowtype.js
+++ b/lib/config/rules/flowtype.js
@@ -2,13 +2,13 @@
 
 module.exports = {
   // Enforces a particular style for boolean type annotations.
-  'flowtype/boolean-style': ['warn', 'boolean'],
+  'flowtype/boolean-style': ['error', 'boolean'],
   // Marks Flow type identifiers as defined.
   'flowtype/define-flow-type': 'error',
   // Enforces consistent use of trailing commas in Object and Tuple annotations.
-  'flowtype/delimiter-dangle': ['warn', 'always-multiline'],
+  'flowtype/delimiter-dangle': ['error', 'always-multiline'],
   // Enforces consistent spacing within generic type annotation parameters.
-  'flowtype/generic-spacing': ['warn', 'never'],
+  'flowtype/generic-spacing': ['error', 'never'],
   // Checks for duplicate properties in Object annotations
   'flowtype/no-dupe-keys': 'error',
   // Disallows use of primitive constructors as types, such as Boolean, Number and String.
@@ -22,29 +22,29 @@ module.exports = {
     Function: true,
   }],
   // Enforces consistent separators between properties in Flow object types.
-  'flowtype/object-type-delimiter': ['warn', 'comma'],
+  'flowtype/object-type-delimiter': ['error', 'comma'],
   // Requires that all function parameters have type annotations.
   'flowtype/require-parameter-type': 'off',
   // Requires that functions have return type annotation.
   'flowtype/require-return-type': 'off',
   // Makes sure that files have a valid @flow annotation.
-  'flowtype/require-valid-file-annotation': ['warn', 'always'],
+  'flowtype/require-valid-file-annotation': ['error', 'always'],
   // Requires that all variable declarators have type annotations.
   'flowtype/require-variable-type': 'off',
   // Enforces consistent use of semicolons after type aliases.
-  'flowtype/semi': ['warn', 'always'],
+  'flowtype/semi': ['error', 'always'],
   // Enforces sorting of Object annotations
   'flowtype/sort-keys': 'off',
   // Enforces consistent spacing after the type annotation colon.
-  'flowtype/space-after-type-colon': ['warn', 'always'],
+  'flowtype/space-after-type-colon': ['error', 'always'],
   // Enforces consistent spacing before the type annotation colon.
-  'flowtype/space-before-type-colon': ['warn', 'never'],
+  'flowtype/space-before-type-colon': ['error', 'never'],
   // Enforces consistent spacing before the opening < of generic type annotation parameters.
-  'flowtype/space-before-generic-bracket': ['warn', 'never'],
+  'flowtype/space-before-generic-bracket': ['error', 'never'],
   // Enforces a consistent naming pattern for type aliases.
   'flowtype/type-id-match': 'off',
   // Enforces consistent spacing around union and intersection type separators (| and &).
-  'flowtype/union-intersection-spacing': 'warn',
+  'flowtype/union-intersection-spacing': 'error',
   // Marks Flow type alias declarations as used.
   'flowtype/use-flow-type': 'error',
   // Checks for simple Flow syntax errors.

--- a/lib/config/rules/import.js
+++ b/lib/config/rules/import.js
@@ -16,7 +16,7 @@ module.exports = {
   // Prevent importing the submodules of other modules
   'import/no-internal-modules': 'off',
   // Reports use of a default export as a locally named import.
-  'import/no-named-default': 'warn',
+  'import/no-named-default': 'error',
   // Restrict which files can be imported in a given folder
   'import/no-restricted-paths': 'off',
   // Forbid import of modules using absolute paths
@@ -29,11 +29,11 @@ module.exports = {
   // Report any invalid exports, i.e. re-export of the same name
   'import/export': 'error',
   // Report use of exported name as identifier of default export
-  'import/no-named-as-default': 'warn',
+  'import/no-named-as-default': 'error',
   // Report use of exported name as property of default export
-  'import/no-named-as-default-member': 'warn',
+  'import/no-named-as-default-member': 'error',
   // Report imported names marked with @deprecated documentation tag
-  'import/no-deprecated': 'warn',
+  'import/no-deprecated': 'error',
   // Forbid the use of extraneous packages
   'import/no-extraneous-dependencies': 'error',
   // Forbid the use of mutable exports with var or let.
@@ -53,22 +53,22 @@ module.exports = {
   // Style guide
 
   // Ensure all imports appear before other statements
-  'import/first': 'warn',
+  'import/first': 'error',
   // Report repeated import of the same module in multiple places
   'import/no-duplicates': 'error',
   // Report namespace imports
   'import/no-namespace': 'off',
   // Ensure consistent use of file extension within the import path
-  'import/extensions': ['warn', {js: 'never', json: 'always'}],
+  'import/extensions': ['error', {js: 'never', json: 'always'}],
   // Enforce a convention in module import order
-  'import/order': ['warn', {
+  'import/order': ['error', {
     groups: [
       ['builtin', 'external'],
       ['internal', 'parent', 'sibling'],
     ],
   }],
   // Enforce a newline after import statements
-  'import/newline-after-import': 'warn',
+  'import/newline-after-import': 'error',
   // Prefer a default export if module exports a single name
   'import/prefer-default-export': 'off',
   // Limit the maximum number of dependencies a module can have

--- a/lib/config/rules/jsx-a11y.js
+++ b/lib/config/rules/jsx-a11y.js
@@ -28,7 +28,7 @@ module.exports = {
   // Enforce iframe elements have a title attribute.
   'jsx-a11y/iframe-has-title': 'error',
   // Enforce <img> alt prop does not contain the word "image", "picture", or "photo".
-  'jsx-a11y/img-redundant-alt': 'warn',
+  'jsx-a11y/img-redundant-alt': 'error',
   // Enforce that elements with interactive handlers like onClick must be focusable.
   'jsx-a11y/interactive-supports-focus': 'error',
   // Enforce that <label> elements have the htmlFor prop.

--- a/lib/config/rules/legacy.js
+++ b/lib/config/rules/legacy.js
@@ -6,7 +6,7 @@ module.exports = {
   // Specify the maximum length of a line in your program
   'max-len': 'off',
   // Limits the number of parameters that can be used in the function declaration.
-  'max-params': ['warn', 10],
+  'max-params': ['error', 10],
   // Specify the maximum number of statement allowed in a function
   'max-statements': 'off',
   // Disallow use of bitwise operators

--- a/lib/config/rules/lodash.js
+++ b/lib/config/rules/lodash.js
@@ -6,7 +6,7 @@ module.exports = {
   // Use or avoid thisArg for Lodash method callbacks, depending on major version.
   'lodash/callback-binding': 'error',
   // Use value returned from collection methods properly.
-  'lodash/collection-method-value': 'warn',
+  'lodash/collection-method-value': 'error',
   // Always return a value in iteratees of Lodash collection methods that aren't forEach.
   'lodash/collection-return': 'error',
   // Do not use .value() on chains that have already ended (e.g. with max() or reduce()) (fixable)
@@ -21,50 +21,50 @@ module.exports = {
   // Stylistic issues
 
   // Enforce a specific chain style: explicit, implicit, or explicit only when necessary.
-  'lodash/chain-style': ['warn', 'explicit'],
+  'lodash/chain-style': ['error', 'explicit'],
   // Prefer a either a Lodash chain or nested Lodash calls
-  'lodash/chaining': ['warn', 'always'],
+  'lodash/chaining': ['error', 'always'],
   // Enforce a specific function composition direction: `flow` or `flowRight`.
-  'lodash/consistent-compose': ['warn', 'flow'],
+  'lodash/consistent-compose': ['error', 'flow'],
   // Prefer identity shorthand syntax
-  'lodash/identity-shorthand': ['warn', 'never'],
+  'lodash/identity-shorthand': ['error', 'never'],
   // Prefer a specific import scope (e.g. lodash/map vs lodash)
   'lodash/import-scope': ['error', 'method'],
   // Prefer matches property shorthand syntax
-  'lodash/matches-prop-shorthand': ['warn', 'never'],
+  'lodash/matches-prop-shorthand': ['error', 'never'],
   // Prefer matches shorthand syntax
-  'lodash/matches-shorthand': ['warn', 'always', 3, true],
+  'lodash/matches-shorthand': ['error', 'always', 3, true],
   // Do not use .commit() on chains that should end with .value()
-  'lodash/no-commit': 'warn',
+  'lodash/no-commit': 'error',
   // Enforce a specific path style for methods like get and property: array, string, or arrays only for deep paths.
-  'lodash/path-style': ['warn', 'string'],
+  'lodash/path-style': ['error', 'string'],
   // Prefer _.compact over _.filter for only truthy values.
-  'lodash/prefer-compact': 'warn',
+  'lodash/prefer-compact': 'error',
   // Prefer _.filter over _.forEach with an if statement inside.
-  'lodash/prefer-filter': 'warn',
+  'lodash/prefer-filter': 'error',
   // Prefer _.flatMap over consecutive map and flatten.
-  'lodash/prefer-flat-map': 'warn',
+  'lodash/prefer-flat-map': 'error',
   // Prefer using _.invoke over _.map with a method call inside.
   'lodash/prefer-invoke-map': 'off',
   // Prefer _.map over _.forEach with a push inside.
   'lodash/prefer-map': 'error',
   // Prefer _.reject over filter with !(expression) or x.prop1 !== value
-  'lodash/prefer-reject': 'warn',
+  'lodash/prefer-reject': 'error',
   // Prefer using _.prototype.thru in the chain and not call functions in the initial value, e.g. _(x).thru(f).map(g)...
   'lodash/prefer-thru': 'off',
   // Prefer using array and string methods in the chain and not the initial value, e.g. _(str).split(' ')...
   'lodash/prefer-wrapper-method': 'off',
   // Prefer using main method names instead of aliases. (fixable)
-  'lodash/preferred-alias': 'warn',
+  'lodash/preferred-alias': 'error',
   // Use/forbid property shorthand syntax.
-  'lodash/prop-shorthand': ['warn', 'never'],
+  'lodash/prop-shorthand': ['error', 'never'],
 
   // Preference over native
 
   // Prefer _.constant over functions returning literals.
   'lodash/prefer-constant': 'off',
   // Prefer using _.get or _.has over expression chains like a && a.b && a.b.c.
-  'lodash/prefer-get': 'warn',
+  'lodash/prefer-get': 'error',
   // Prefer _.includes over comparing indexOf to -1.
   'lodash/prefer-includes': 'off',
   // Prefer _.isNil over checks for both null and undefined.

--- a/lib/config/rules/mocha.js
+++ b/lib/config/rules/mocha.js
@@ -2,13 +2,13 @@
 
 module.exports = {
   // Disallow exclusive mocha tests.
-  'mocha/no-exclusive-tests': 'warn',
+  'mocha/no-exclusive-tests': 'error',
   // Disallow skipped mocha tests.
   'mocha/no-skipped-tests': 'error',
   // Disallow pending/unimplemented mocha tests.
-  'mocha/no-pending-tests': 'warn',
+  'mocha/no-pending-tests': 'error',
   // Enforces handling of callbacks for async tests.
-  'mocha/handle-done-callback': 'warn',
+  'mocha/handle-done-callback': 'error',
   // Disallow global tests.
   'mocha/no-global-tests': 'error',
   // Disallow hooks
@@ -16,7 +16,7 @@ module.exports = {
   // Disallow hooks for a single test or test suite
   'mocha/no-hooks-for-single-case': 'off',
   // Disallow identical titles
-  'mocha/no-identical-title': 'warn',
+  'mocha/no-identical-title': 'error',
   // Disallow arrow functions as arguments to mocha globals
   'mocha/no-mocha-arrows': 'off',
   // Disallow returning in a test or hook function that uses a callback
@@ -34,5 +34,5 @@ module.exports = {
   // Match test descriptions to match a pre-configured regular expression
   'mocha/valid-test-description': 'off',
   // Limit the number of top-level suites in a single file
-  'mocha/max-top-level-suites': ['warn', {limit: 1}],
+  'mocha/max-top-level-suites': ['error', {limit: 1}],
 };

--- a/lib/config/rules/node.js
+++ b/lib/config/rules/node.js
@@ -2,19 +2,19 @@
 
 module.exports = {
   // enforce return after a callback
-  'callback-return': ['warn', ['callback', 'cb', 'next']],
+  'callback-return': ['error', ['callback', 'cb', 'next']],
   // disallow require() outside of the top-level module scope
   'global-require': 'off',
   // Enforces error handling in callbacks
-  'handle-callback-err': ['warn', '^.*(e|E)rr(or)?$'],
+  'handle-callback-err': ['error', '^.*(e|E)rr(or)?$'],
   // disallow use of the Buffer() constructor
   'no-buffer-constructor': 'error',
   // Disallow mixing regular variable and require declarations
   'no-mixed-requires': 'off',
   // Disallow use of new operator with the require function
-  'no-new-require': 'warn',
+  'no-new-require': 'error',
   // Disallow string concatenation with __dirname and __filename
-  'no-path-concat': 'warn',
+  'no-path-concat': 'error',
   // Disallow process.exit()
   'no-process-exit': 'off',
   // Restrict usage of specified node imports
@@ -29,9 +29,9 @@ module.exports = {
   // disallow require() expressions of extraneous packages
   'node/no-extraneous-require': 'error',
   // Enforce either module.exports or exports.
-  'node/exports-style': ['warn', 'module.exports'],
+  'node/exports-style': ['error', 'module.exports'],
   // Disallow deprecated API.
-  'node/no-deprecated-api': 'warn',
+  'node/no-deprecated-api': 'error',
   // Disallow import and export declarations for files that don't exist.
   'node/no-missing-import': 'off',
   // Disallow require()s for files that don't exist.

--- a/lib/config/rules/possible-errors.js
+++ b/lib/config/rules/possible-errors.js
@@ -10,17 +10,17 @@ module.exports = {
   // Disallow comparing against -0
   'no-compare-neg-zero': 'error',
   // Disallow or enforce trailing commas
-  'comma-dangle': ['warn', 'always-multiline'],
+  'comma-dangle': ['error', 'always-multiline'],
   // Disallow assignment in conditional expressions
   'no-cond-assign': 'error',
   // Disallow use of console
-  'no-console': 'warn',
+  'no-console': 'error',
   // Disallow use of constant expressions in conditions
-  'no-constant-condition': ['warn', {checkLoops: false}],
+  'no-constant-condition': ['error', {checkLoops: false}],
   // Disallow control characters in regular expressions
   'no-control-regex': 'error',
   // Disallow use of debugger
-  'no-debugger': 'warn',
+  'no-debugger': 'error',
   // Disallow duplicate arguments in functions
   'no-dupe-args': 'error',
   // Disallow duplicate keys when creating object literals
@@ -30,31 +30,31 @@ module.exports = {
   // Disallow the use of empty character classes in regular expressions
   'no-empty-character-class': 'error',
   // Disallow empty statements
-  'no-empty': 'warn',
+  'no-empty': 'error',
   // Disallow assigning to the exception in a catch block
   'no-ex-assign': 'error',
   // Disallow double-negation boolean casts in a boolean context
-  'no-extra-boolean-cast': 'warn',
+  'no-extra-boolean-cast': 'error',
   // Disallow unnecessary parentheses
   'no-extra-parens': 'off',
   // Disallow unnecessary semicolons
-  'no-extra-semi': 'warn',
+  'no-extra-semi': 'error',
   // Disallow overwriting functions written as function declarations
-  'no-func-assign': 'warn',
+  'no-func-assign': 'error',
   // Disallow function or variable declarations in nested blocks
-  'no-inner-declarations': 'warn',
+  'no-inner-declarations': 'error',
   // Disallow invalid regular expression strings in the RegExp constructor
   'no-invalid-regexp': 'error',
   // Disallow irregular whitespace outside of strings and comments
-  'no-irregular-whitespace': 'warn',
+  'no-irregular-whitespace': 'error',
   // Disallow the use of object properties of the global object (Math and JSON) as functions
   'no-obj-calls': 'error',
   // Disallow use of Object.prototypes builtins directly
   'no-prototype-builtins': 'off',
   // Disallow multiple spaces in a regular expression literal
-  'no-regex-spaces': 'warn',
+  'no-regex-spaces': 'error',
   // Disallow sparse arrays
-  'no-sparse-arrays': 'warn',
+  'no-sparse-arrays': 'error',
   // Disallow template literal placeholder syntax in regular strings
   'no-template-curly-in-string': 'error',
   // Disallow unreachable statements after a return, throw, continue, or break statement
@@ -62,7 +62,7 @@ module.exports = {
   // Disallow control flow statements in finally blocks
   'no-unsafe-finally': 'error',
   // Disallow negation of the left operand of an in expression
-  'no-unsafe-negation': 'warn',
+  'no-unsafe-negation': 'error',
   // Disallow comparisons with the value NaN
   'use-isnan': 'error',
   // Ensure JSDoc comments are valid
@@ -70,5 +70,5 @@ module.exports = {
   // Ensure that the results of typeof are compared against a valid string
   'valid-typeof': 'error',
   // Avoid code that looks like two expressions but is actually one
-  'no-unexpected-multiline': 'warn',
+  'no-unexpected-multiline': 'error',
 };

--- a/lib/config/rules/promise.js
+++ b/lib/config/rules/promise.js
@@ -5,17 +5,17 @@ module.exports = {
 
   'promise/always-catch': 'off',
   // Ensure that each time a then() is applied to a promise, a catch() is applied as well. Exceptions are made if you are returning that promise.
-  'promise/catch-or-return': 'warn',
+  'promise/catch-or-return': 'error',
   // Avoid wrapping values in Promise.resolve or Promise.reject when not needed
   'promise/no-return-wrap': 'error',
   // Ensure that inside a then() you make sure to return a new promise or value.
   'promise/always-return': 'error',
   // Enforce standard parameter names for Promise constructors.
-  'promise/param-names': 'warn',
+  'promise/param-names': 'error',
   // Ensure that Promise is included fresh in each file instead of relying on the existence of a native promise implementation.
   'promise/no-native': 'off',
   // Avoid nested .then() or .catch() statements
-  'promise/no-nesting': 'warn',
+  'promise/no-nesting': 'error',
   // Avoid using promises inside of callbacks
   'promise/no-promise-in-callback': 'off',
   // Avoid calling cb() inside of a then() (use nodeify instead)

--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -4,7 +4,7 @@ module.exports = {
   // Enforces consistent naming for boolean props
   'react/boolean-prop-naming': 'off',
   // Prevent missing displayName in a React component definition
-  'react/display-name': ['warn', {ignoreTranspilerName: false}],
+  'react/display-name': ['error', {ignoreTranspilerName: false}],
   // Prevent extraneous defaultProps on components
   'react/default-props-match-prop-types': 'error',
   // Forbid certain props on Components
@@ -18,11 +18,11 @@ module.exports = {
   // Prevent using Array index in key prop
   'react/no-array-index-key': 'error',
   // Prevent passing children as props
-  'react/no-children-prop': 'warn',
+  'react/no-children-prop': 'error',
   // Prevent usage of dangerous JSX properties
   'react/no-danger': 'off',
   // Prevent problem with children and props.dangerouslySetInnerHTML
-  'react/no-danger-with-children': 'warn',
+  'react/no-danger-with-children': 'error',
   // Prevent usage of deprecated methods
   'react/no-deprecated': 'error',
   // Prevent usage of setState in componentDidMount
@@ -46,13 +46,13 @@ module.exports = {
   // Prevent common casing typos
   'react/no-typos': 'error',
   // Prevent using string references in ref attribute.
-  'react/no-string-refs': 'warn',
+  'react/no-string-refs': 'error',
   // Prevent invalid characters from appearing in markup
   'react/no-unescaped-entities': 'error',
   // Prevent usage of unknown DOM property
   'react/no-unknown-property': 'off',
   // Prevent definitions of unused prop types
-  'react/no-unused-prop-types': 'warn',
+  'react/no-unused-prop-types': 'error',
   // Attempts to discover all state fields in a React component and warn if any of them are never read.
   'react/no-unused-state': 'error',
   // Prevent usage of setState in componentWillUpdate
@@ -60,9 +60,9 @@ module.exports = {
   // Enforce ES5 or ES6 class for React Components
   'react/prefer-es6-class': 'error',
   // Enforce stateless React Components to be written as a pure function
-  'react/prefer-stateless-function': ['warn', {ignorePureComponents: true}],
+  'react/prefer-stateless-function': ['error', {ignorePureComponents: true}],
   // Prevent missing props validation in a React component definition
-  'react/prop-types': 'warn',
+  'react/prop-types': 'error',
   // Prevent missing React when using JSX
   'react/react-in-jsx-scope': 'error',
   // Enforce a defaultProps definition for every prop that is not a required prop
@@ -72,7 +72,7 @@ module.exports = {
   // Enforce ES5 or ES6 class for returning value in render function
   'react/require-render-return': 'error',
   // Prevent extra closing tags for components without children
-  'react/self-closing-comp': 'warn',
+  'react/self-closing-comp': 'error',
   // Enforce component methods order
   'react/sort-comp': 'off',
   // Enforce propTypes declarations alphabetical sorting
@@ -85,31 +85,31 @@ module.exports = {
   // JSX
 
   // Enforce boolean attributes notation in JSX
-  'react/jsx-boolean-value': 'warn',
+  'react/jsx-boolean-value': 'error',
   // Validate closing bracket location in JSX
-  'react/jsx-closing-bracket-location': ['warn', {location: 'tag-aligned'}],
+  'react/jsx-closing-bracket-location': ['error', {location: 'tag-aligned'}],
   // Validate closing tag location in JSX
   'react/jsx-closing-tag-location': 'error',
   // Enforce or disallow spaces inside of curly braces in JSX attributes
-  'react/jsx-curly-spacing': ['warn', 'never', {allowMultiline: true}],
+  'react/jsx-curly-spacing': ['error', 'never', {allowMultiline: true}],
   // Enforce or disallow spaces around equal signs in JSX attributes
-  'react/jsx-equals-spacing': ['warn', 'never'],
+  'react/jsx-equals-spacing': ['error', 'never'],
   // Restrict file extensions that may contain JSX
-  'react/jsx-filename-extension': ['warn', {extensions: ['.js']}],
+  'react/jsx-filename-extension': ['error', {extensions: ['.js']}],
   // Enforce position of the first prop in JSX
-  'react/jsx-first-prop-new-line': ['warn', 'multiline'],
+  'react/jsx-first-prop-new-line': ['error', 'multiline'],
   // Enforce event handler naming conventions in JSX
   'react/jsx-handler-names': 'off',
   // Validate props indentation in JSX
-  'react/jsx-indent-props': ['warn', 2],
+  'react/jsx-indent-props': ['error', 2],
   // Validate JSX indentation
-  'react/jsx-indent': ['warn', 2],
+  'react/jsx-indent': ['error', 2],
   // Validate JSX has key prop when in array or iterator
   'react/jsx-key': 'error',
   // Limit maximum of props on a single line in JSX
   'react/jsx-max-props-per-line': 'off',
   // Prevent usage of .bind() and arrow functions in JSX props
-  'react/jsx-no-bind': 'warn',
+  'react/jsx-no-bind': 'error',
   // Prevent comments from being inserted as text nodes
   'react/jsx-no-comment-textnodes': 'error',
   // Prevent duplicate props in JSX
@@ -127,11 +127,11 @@ module.exports = {
   // Enforce propTypes declarations alphabetical sorting (deprecated)
   'react/jsx-sort-prop-types': 'off',
   // Validate whitespace in and around the JSX opening and closing brackets
-  'react/jsx-tag-spacing': 'warn',
+  'react/jsx-tag-spacing': 'error',
   // Prevent React to be incorrectly marked as unused
   'react/jsx-uses-react': 'error',
   // Prevent variables used in JSX to be incorrectly marked as unused
   'react/jsx-uses-vars': 'error',
   // Prevent missing parentheses around multilines JSX
-  'react/jsx-wrap-multilines': 'warn',
+  'react/jsx-wrap-multilines': 'error',
 };

--- a/lib/config/rules/shopify.js
+++ b/lib/config/rules/shopify.js
@@ -1,8 +1,8 @@
 module.exports = {
   // Requires (or disallows) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
-  'shopify/binary-assignment-parens': ['warn', 'always'],
+  'shopify/binary-assignment-parens': ['error', 'always'],
   // Requires (or disallows) semicolons for class properties.
-  'shopify/class-property-semi': 'warn',
+  'shopify/class-property-semi': 'error',
   // Requires that all jQuery objects are assigned to references prefixed with `$`.
   'shopify/jquery-dollar-sign-reference': 'off',
   // Prevents the usage of unnecessary computed properties.
@@ -12,9 +12,9 @@ module.exports = {
   // Prefer class properties to assignment of literals in constructors.
   'shopify/prefer-class-properties': 'off',
   // Prefer early returns over full-body conditional wrapping in function declarations.
-  'shopify/prefer-early-return': ['warn', {maximumStatements: 1}],
+  'shopify/prefer-early-return': ['error', {maximumStatements: 1}],
   // Prefer Twine over Bindings as the name for twine imports.
-  'shopify/prefer-twine': 'warn',
+  'shopify/prefer-twine': 'error',
   // Prevents importing the entirety of a package.
   'shopify/restrict-full-import': 'off',
   // Restricts the use of specified sinon features.

--- a/lib/config/rules/sort-class-members.js
+++ b/lib/config/rules/sort-class-members.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   'sort-class-members/sort-class-members': [
-    'warn',
+    'error',
     {
       order: [
         '[static-members]',

--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -4,41 +4,41 @@ module.exports = {
   // enforce linebreaks after opening and before closing array brackets
   'array-bracket-newline': 'off',
   // Enforce spacing inside array brackets
-  'array-bracket-spacing': ['warn', 'never'],
+  'array-bracket-spacing': ['error', 'never'],
   // enforce line breaks after each array element
   'array-element-newline': 'off',
   // Disallow or enforce spaces inside of single line blocks
-  'block-spacing': ['warn', 'always'],
+  'block-spacing': ['error', 'always'],
   // Enforce one true brace style
-  'brace-style': ['warn', '1tbs', {allowSingleLine: true}],
+  'brace-style': ['error', '1tbs', {allowSingleLine: true}],
   // Require camel case names
-  'camelcase': ['warn', {properties: 'always'}],
+  'camelcase': ['error', {properties: 'always'}],
   // Enforce or disallow capitalization of the first letter of a comment
   'capitalized-comments': 'off',
   // Enforce spacing before and after comma
-  'comma-spacing': ['warn', {before: false, after: true}],
+  'comma-spacing': ['error', {before: false, after: true}],
   // Enforce one true comma style
-  'comma-style': ['warn', 'last'],
+  'comma-style': ['error', 'last'],
   // Require or disallow padding inside computed properties
-  'computed-property-spacing': ['warn', 'never'],
+  'computed-property-spacing': ['error', 'never'],
   // Enforces consistent naming when capturing the current execution context
-  'consistent-this': ['warn', 'self'],
+  'consistent-this': ['error', 'self'],
   // Enforce newline at the end of file, with no multiple empty lines
-  'eol-last': 'warn',
+  'eol-last': 'error',
   // Disallow space between function identifier and application
-  'func-call-spacing': 'warn',
+  'func-call-spacing': 'error',
   // Require function names to match the name of the variable or property to which they are assigned
-  'func-name-matching': 'warn',
+  'func-name-matching': 'error',
   // Don't require function expressions to have a name
   'func-names': 'off',
   // Enforces use of function declarations or expressions
-  'func-style': ['warn', 'declaration'],
+  'func-style': ['error', 'declaration'],
   // enforce consistent line breaks inside function parentheses
   'function-paren-newline': ['error', 'consistent'],
   // Blacklist certain identifiers to prevent them being used
   'id-blacklist': 'off',
   // This option enforces minimum and maximum identifier lengths (variable names, property names etc.)
-  'id-length': ['warn', {
+  'id-length': ['error', {
     min: 2,
     properties: 'always',
     exceptions: ['x', 'y', 'i', 'j', 't', '_', '$'],
@@ -48,37 +48,37 @@ module.exports = {
   // Disable eslint v4 stricter indent rules
   'indent': 'off',
   // Use eslint v3 indent rules: This option sets a specific tab width for your code
-  'indent-legacy': ['warn', 2, {SwitchCase: 1, MemberExpression: 1}],
+  'indent-legacy': ['error', 2, {SwitchCase: 1, MemberExpression: 1}],
   // Specify whether double or single quotes should be used in JSX attributes
-  'jsx-quotes': ['warn', 'prefer-double'],
+  'jsx-quotes': ['error', 'prefer-double'],
   // Enforces spacing between keys and values in object literal properties
-  'key-spacing': ['warn', {beforeColon: false, afterColon: true}],
+  'key-spacing': ['error', {beforeColon: false, afterColon: true}],
   // Enforce spacing before and after keywords
-  'keyword-spacing': ['warn', {before: true, after: true, overrides: {}}],
+  'keyword-spacing': ['error', {before: true, after: true, overrides: {}}],
   // Disallow mixed "LF" and "CRLF" as linebreaks
   'linebreak-style': 'off',
   // Enforces empty lines around comments
-  'lines-around-comment': ['warn', {beforeBlockComment: true}],
+  'lines-around-comment': ['error', {beforeBlockComment: true}],
   // Enforce position of line comments
-  'line-comment-position': ['warn', {position: 'above'}],
+  'line-comment-position': ['error', {position: 'above'}],
   // Enforce a maximum file length
   'max-lines': 'off',
   // Specify the maximum depth callbacks can be nested
   'max-nested-callbacks': 'off',
   // Specify the maximum number of statements allowed per line
-  'max-statements-per-line': ['warn', {max: 2}],
+  'max-statements-per-line': ['error', {max: 2}],
   // Enforce newlines between operands of ternary expressions
   'multiline-ternary': 'off',
   // Require a capital letter for constructors
   'new-cap': ['error', {newIsCap: true, capIsNew: false}],
   // Disallow the omission of parentheses when invoking a constructor with no arguments
-  'new-parens': 'warn',
+  'new-parens': 'error',
   // Allow/disallow an empty newline after var statement
   'newline-after-var': 'off',
   // Require newline before `return` statement
   'newline-before-return': 'off',
   // Enforce newline after each call when chaining the calls
-  'newline-per-chained-call': ['warn', {ignoreChainWithDepth: 3}],
+  'newline-per-chained-call': ['error', {ignoreChainWithDepth: 3}],
   // Disallow use of the Array constructor
   'no-array-constructor': 'error',
   // Disallow use of the continue statement
@@ -86,33 +86,33 @@ module.exports = {
   // Disallow comments inline after code
   'no-inline-comments': 'off',
   // Disallow if as the only statement in an else block
-  'no-lonely-if': 'warn',
+  'no-lonely-if': 'error',
   // Disallow mixes of different operators
-  'no-mixed-operators': 'warn',
+  'no-mixed-operators': 'error',
   // Disallow mixed spaces and tabs for indentation
-  'no-mixed-spaces-and-tabs': 'warn',
+  'no-mixed-spaces-and-tabs': 'error',
   // Disallow use of chained assignment expressions
   'no-multi-assign': 'error',
   // Disallow multiple empty lines
-  'no-multiple-empty-lines': 'warn',
+  'no-multiple-empty-lines': 'error',
   // Disallow negated conditions
-  'no-negated-condition': 'warn',
+  'no-negated-condition': 'error',
   // Disallow nested ternary expressions
-  'no-nested-ternary': 'warn',
+  'no-nested-ternary': 'error',
   // Disallow use of the Object constructor
-  'no-new-object': 'warn',
+  'no-new-object': 'error',
   // Disallow specified syntax
   'no-restricted-syntax': 'off',
   // Disallow tabs in file
-  'no-tabs': 'warn',
+  'no-tabs': 'error',
   // Disallow the use of ternary operators
   'no-ternary': 'off',
   // Disallow trailing whitespace at the end of lines
-  'no-trailing-spaces': 'warn',
+  'no-trailing-spaces': 'error',
   // Allow dangling underscores in identifiers
   'no-underscore-dangle': 'off',
   // Disallow the use of Boolean literals in conditional expressions
-  'no-unneeded-ternary': 'warn',
+  'no-unneeded-ternary': 'error',
   // Disallow whitespace before properties
   'no-whitespace-before-property': 'error',
   // Enforce the location of single-line statements
@@ -120,17 +120,17 @@ module.exports = {
   // Enforce consistent line breaks inside braces
   'object-curly-newline': 'off',
   // Require or disallow padding inside curly braces
-  'object-curly-spacing': ['warn', 'never'],
+  'object-curly-spacing': ['error', 'never'],
   // Enforce placing object properties on separate lines
   'object-property-newline': 'off',
   // Allow or disallow one variable declaration per function
-  'one-var': ['warn', 'never'],
+  'one-var': ['error', 'never'],
   // Require or disallow an newline around variable declarations
-  'one-var-declaration-per-line': ['warn', 'initializations'],
+  'one-var-declaration-per-line': ['error', 'initializations'],
   // Require assignment operator shorthand where possible or prohibit it entirely
-  'operator-assignment': ['warn', 'always'],
+  'operator-assignment': ['error', 'always'],
   // Enforce operators to be placed before or after line breaks
-  'operator-linebreak': ['warn', 'after', {overrides: {'?': 'before', ':': 'before'}}],
+  'operator-linebreak': ['error', 'after', {overrides: {'?': 'before', ':': 'before'}}],
   // Enforce padding within blocks
   'padded-blocks': 'off',
   // require or disallow padding lines between statements
@@ -140,23 +140,23 @@ module.exports = {
     {blankLine: 'any', prev: 'directive', next: 'directive'},
   ],
   // Require quotes around object literal property names
-  'quote-props': ['warn', 'as-needed'],
+  'quote-props': ['error', 'as-needed'],
   // Specify whether backticks, double or single quotes should be used
-  'quotes': ['warn', 'single', 'avoid-escape'],
+  'quotes': ['error', 'single', 'avoid-escape'],
   // Require JSDoc comments
   'require-jsdoc': 'off',
   // Enforce spacing before and after semicolons
-  'semi-spacing': ['warn', {before: false, after: true}],
+  'semi-spacing': ['error', {before: false, after: true}],
   // enforce location of semicolons
   'semi-style': ['error', 'last'],
   // Require or disallow use of semicolons instead of ASI
-  'semi': ['warn', 'always'],
+  'semi': ['error', 'always'],
   // Requires object keys to be sorted
   'sort-keys': 'off',
   // Sort variables within the same declaration block
   'sort-vars': 'off',
   // Require or disallow space before blocks
-  'space-before-blocks': ['warn', 'always'],
+  'space-before-blocks': ['error', 'always'],
   // Require or disallow space before function opening parenthesis
   'space-before-function-paren': ['error', {
     anonymous: 'never',
@@ -164,19 +164,19 @@ module.exports = {
     asyncArrow: 'always',
   }],
   // Require or disallow spaces inside parentheses
-  'space-in-parens': ['warn', 'never'],
+  'space-in-parens': ['error', 'never'],
   // Require spaces around operators
-  'space-infix-ops': 'warn',
+  'space-infix-ops': 'error',
   // Require or disallow spaces before/after unary operators (words on by default, nonwords)
-  'space-unary-ops': ['warn', {words: true, nonwords: false}],
+  'space-unary-ops': ['error', {words: true, nonwords: false}],
   // Require or disallow a space immediately following the // or /* in a comment
-  'spaced-comment': ['warn', 'always', {markers: ['=']}],
+  'spaced-comment': ['error', 'always', {markers: ['=']}],
   // enforce spacing around colons of switch statements
   'switch-colon-spacing': ['error', {'after': true, 'before': false}],
   // Require or disallow spacing between template tags and their literals
   'template-tag-spacing': ['error', 'never'],
   // Require or disallow the Unicode BOM
-  'unicode-bom': ['warn', 'never'],
+  'unicode-bom': ['error', 'never'],
   // Require regex literals to be wrapped in parentheses
   'wrap-regex': 'off',
 };

--- a/lib/config/rules/variables.js
+++ b/lib/config/rules/variables.js
@@ -22,7 +22,7 @@ module.exports = {
   // Disallow use of undefined variable
   'no-undefined': 'error',
   // Disallow declaration of variables that are not used in the code
-  'no-unused-vars': 'warn',
+  'no-unused-vars': 'error',
   // Disallow use of variables before they are defined
   'no-use-before-define': ['error', 'nofunc'],
 };


### PR DESCRIPTION
We pretty much treat all `warn` as `error` anyways, let's make this explicit. 