### PR TITLE
Turn off babel/semi in prettier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+## [17.2.1] - 2017-10-30
+### Changed
+* Turned off `babel/semi` rule in prettier config
+
 ## [17.2.0] - 2017-10-25
 ### Added
 * Added a prettier config [[#46](https://github.com/Shopify/eslint-plugin-shopify/pull/46)]

--- a/lib/config/prettier.js
+++ b/lib/config/prettier.js
@@ -16,5 +16,6 @@ module.exports = {
 
     // rules to disable to prefer prettier
     'shopify/binary-assignment-parens': 'off',
+    'babel/semi': 'off',
   },
 };


### PR DESCRIPTION
tl;dr The `babel/semi` rule conflicts with vscodes autofix. 

When a semi-colon is missing, prettier appends one, then `babel-semi` appends one, resulting in an extra semi-colon. This also forces users who uses vscode/eslint plugin to `ctrl+s` an extra time to strip out the second `;`. 