### PR TITLE
Pull out esnext config from prettier config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Changed
+* Removed `plugin:shopify/esnext` as an included extension of the `plugin:shopify/prettier` config. `plugin:shopify/esnext` must now be extended by the consumer to use the `plugin:shopify/prettier`.
+
+  Example (`package.json`):
+  ```
+  "eslintConfig": {
+    "extends": [
+      "plugin:shopify/esnext",
+      "plugin:shopify/prettier"
+    ]
+  }
+  ```
+
 ## [18.0.0] - 2017-10-31
 ### Changed
 * Turned off `class-methods-use-this`

--- a/lib/config/prettier.js
+++ b/lib/config/prettier.js
@@ -1,5 +1,5 @@
 module.exports = {
-  extends: ['plugin:shopify/esnext', 'prettier'],
+  extends: ['prettier'],
 
   plugins: ['prettier'],
 

--- a/lib/rules/restrict-full-import.js
+++ b/lib/rules/restrict-full-import.js
@@ -70,8 +70,8 @@ module.exports = {
             specifiers.length > 1
               ? specifiers.find(isFullImportSpecifier)
               : node,
-          message: `Unexpected full import of restricted module '${node.source
-            .value}'.`,
+          // prettier-ignore
+          message: `Unexpected full import of restricted module '${node.source.value}'.`,
         });
       }
     }
@@ -83,8 +83,8 @@ module.exports = {
       ) {
         context.report({
           node,
-          message: `Unexpected full import of restricted module '${right
-            .arguments[0].value}'.`,
+          // prettier-ignore
+          message: `Unexpected full import of restricted module '${right.arguments[0].value}'.`,
         });
       }
     }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "extends": [
       "plugin:shopify/es5",
       "plugin:shopify/node",
+      "plugin:shopify/esnext",
       "plugin:shopify/prettier"
     ]
   },

--- a/tests/lib/rules/restrict-full-import.js
+++ b/tests/lib/rules/restrict-full-import.js
@@ -14,6 +14,7 @@ const parserOptions = {
 };
 
 const options = [['lodash']];
+// prettier-ignore
 const message = `Unexpected full import of restricted module '${options[0][0]}'.`;
 
 ruleTester.run('restrict-full-import', rule, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1505,7 +1505,7 @@ eslint-plugin-react@^7.3.0:
     prop-types "^15.5.10"
 
 "eslint-plugin-shopify@file:./.":
-  version "17.2.0-alpha.1"
+  version "18.0.0"
   dependencies:
     babel-eslint "^8.0.0"
     eslint-config-prettier "^2.6.0"
@@ -1524,7 +1524,7 @@ eslint-plugin-react@^7.3.0:
     eslint-plugin-sort-class-members "^1.2.0"
     merge "^1.2.0"
   optionalDependencies:
-    prettier "<1.8 >= 1.7.2"
+    prettier "<2.0 >= 1.7.2"
 
 eslint-plugin-sort-class-members@^1.2.0:
   version "1.2.2"
@@ -2841,9 +2841,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-"prettier@<1.8 >= 1.7.2":
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
+"prettier@<2.0 >= 1.7.2":
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
 
 private@^0.1.6, private@^0.1.7:
   version "0.1.8"


### PR DESCRIPTION
This PR removes the extended `esnext` config from the `prettier` config. 

**Why?:**
This allows us to extend the `prettier` config on top of `typescript`/`typescript-react` (WIP) config without conflicts. 

This will be a breaking change; consumers will have to prepend the `esnext` config to their eslint config wherever the `prettier` eslint config is used.

Open to alternatives suggestions. 