### PR TITLE
Add trailing comma function support to comma-dangle and prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "bracketSpacing": false,
+  "trailingComma": "all"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Changed
 
+* `plugin:shopify/prettier` will now enforce trailing commas in function
+  parameter calls
 * `comma-dangle` will now enforce multi-line function parameters
 * Removed `plugin:shopify/esnext` as an included extension of the
   `plugin:shopify/prettier` config. `plugin:shopify/esnext` must now be extended

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@
 * Added a `typescript` and `typescript-react` config [[#54](https://github.com/Shopify/eslint-plugin-shopify/pull/54)]
 
 ### Changed
-* Removed `plugin:shopify/esnext` as an included extension of the `plugin:shopify/prettier` config. `plugin:shopify/esnext` must now be extended by the consumer to use the `plugin:shopify/prettier`.
+
+* `comma-dangle` will now enforce multi-line function parameters
+* Removed `plugin:shopify/esnext` as an included extension of the
+  `plugin:shopify/prettier` config. `plugin:shopify/esnext` must now be extended
+  by the consumer to use the `plugin:shopify/prettier`.
 
   Example (`package.json`):
+
   ```
   "eslintConfig": {
     "extends": [
@@ -19,18 +24,26 @@
   ```
 
 ## [18.0.0] - 2017-10-31
+
 ### Changed
+
 * Turned off `class-methods-use-this`
 
 ## [17.2.1] - 2017-10-30
+
 ### Changed
+
 * Turned off `babel/semi` rule in prettier config
 
 ## [17.2.0] - 2017-10-25
+
 ### Added
-* Added a prettier config [[#46](https://github.com/Shopify/eslint-plugin-shopify/pull/46)]
+
+* Added a prettier config
+  [[#46](https://github.com/Shopify/eslint-plugin-shopify/pull/46)]
 
 Example:
+
 ```
 "eslintConfig": {
   "extends": [
@@ -40,132 +53,208 @@ Example:
 ```
 
 ### Changed
-* Replace all `warn` with `error` [[#48](https://github.com/Shopify/eslint-plugin-shopify/pull/48)]
-* `space-before-function-paren` now uses `asyncArrow` option (eg. `async () => {}`) [[#43](https://github.com/Shopify/eslint-plugin-shopify/pull/43)]
-* Enable `padding-line-between-statements` for directives.  [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
+
+* Replace all `warn` with `error`
+  [[#48](https://github.com/Shopify/eslint-plugin-shopify/pull/48)]
+* `space-before-function-paren` now uses `asyncArrow` option (eg. `async () =>
+  {}`) [[#43](https://github.com/Shopify/eslint-plugin-shopify/pull/43)]
+* Enable `padding-line-between-statements` for directives.
+  [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
 ### Removed
-* `lines-around-directive` was deprecated in ESLint `v4.0.0`. [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
+* `lines-around-directive` was deprecated in ESLint `v4.0.0`.
+  [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
 ## [17.1.0] - 2017-09-19
 
 ### Added
-* New rules ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
-  - `import/no-anonymous-default-export`
-  - `jsx-a11y/anchor-is-valid`
-  - `no-buffer-constructor`
-  - `node/no-extraneous-import` (disabled)
-  - `node/no-extraneous-require`
-  - `for-direction`
-  - `getter-return`
-  - `react/boolean-prop-naming` (disabled)
-  - `react/default-props-match-prop-types`
-  - `react/no-redundant-should-component-update`
-  - `react/no-typos`
-  - `react/no-unused-state`
-  - `react/jsx-closing-tag-location`
-  - `array-bracket-newline` (disabled)
-  - `array-element-newline` (disabled)
-  - `function-paren-newline`
-  - `padding-line-between-statements` (disabled)
-  - `semi-style`
-  - `switch-colon-spacing`
 
+* New rules ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
+  * `import/no-anonymous-default-export`
+  * `jsx-a11y/anchor-is-valid`
+  * `no-buffer-constructor`
+  * `node/no-extraneous-import` (disabled)
+  * `node/no-extraneous-require`
+  * `for-direction`
+  * `getter-return`
+  * `react/boolean-prop-naming` (disabled)
+  * `react/default-props-match-prop-types`
+  * `react/no-redundant-should-component-update`
+  * `react/no-typos`
+  * `react/no-unused-state`
+  * `react/jsx-closing-tag-location`
+  * `array-bracket-newline` (disabled)
+  * `array-element-newline` (disabled)
+  * `function-paren-newline`
+  * `padding-line-between-statements` (disabled)
+  * `semi-style`
+  * `switch-colon-spacing`
 
 ### Changed
-- Updated dependencies ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
-  - `eslint`
-  - `babel-eslint`
-  - `eslint-plugin-import`
-  - `eslint-plugin-jsx-a11y`
-  - `eslint-plugin-node`
-  - `eslint-plugin-react`
-- `jquery-dollar-sign-reference` no longer flags assignments from `await` expressions
+
+* Updated dependencies
+  ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
+  * `eslint`
+  * `babel-eslint`
+  * `eslint-plugin-import`
+  * `eslint-plugin-jsx-a11y`
+  * `eslint-plugin-node`
+  * `eslint-plugin-react`
+* `jquery-dollar-sign-reference` no longer flags assignments from `await`
+  expressions
 
 ### Removed
-- `jsx-a11y/href-no-hash` replaced with `jsx-a11y/anchor-is-valid`
+
+* `jsx-a11y/href-no-hash` replaced with `jsx-a11y/anchor-is-valid`
 
 ## [17.0.0] - 2017-08-17
-### Changed
-- `eslint` upgrade to `4.3.0`
-- `node.js` minimum supported node version update to `6.11.1` (LTS).
-- Update dependencies:
-  - `eslint-plugin-ava`: `^4.2.0` → `^4.2.1`.
-  - `eslint-plugin-babel`: `^4.1.1` → `^4.1.2`.
-  - `eslint-plugin-lodash`: `^2.4.2` → `^2.4.4`.
-  - `eslint-plugin-mocha`: `^4.9.0` → `^4.11.0`.
-  - `eslint-plugin-node`: `^4.2.2` → `^4.2.3`.
-  - `eslint-plugin-react`: `^7.0.0` → `^7.0.1`.
 
+### Changed
+
+* `eslint` upgrade to `4.3.0`
+* `node.js` minimum supported node version update to `6.11.1` (LTS).
+* Update dependencies:
+  * `eslint-plugin-ava`: `^4.2.0` → `^4.2.1`.
+  * `eslint-plugin-babel`: `^4.1.1` → `^4.1.2`.
+  * `eslint-plugin-lodash`: `^2.4.2` → `^2.4.4`.
+  * `eslint-plugin-mocha`: `^4.9.0` → `^4.11.0`.
+  * `eslint-plugin-node`: `^4.2.2` → `^4.2.3`.
+  * `eslint-plugin-react`: `^7.0.0` → `^7.0.1`.
 
 ## [16.0.1] - 2017-05-29
+
 ### Changed
-- Turned off [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring) ([#30](https://github.com/Shopify/eslint-plugin-shopify/pull/30))
+
+* Turned off
+  [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring)
+  ([#30](https://github.com/Shopify/eslint-plugin-shopify/pull/30))
 
 ## [16.0.0] - 2017-05-16
+
 ### Added
-- New rule: [`babel/semi`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.0)
-- New rule: [`flowtype/no-types-missing-file-annotation`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-no-types-missing-file-annotation)
-- New rule: [`jsx-a11y/accessible-emoji`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md)
-- New rule: [`jsx-a11y/alt-text`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md)
-- New rule: [`jsx-a11y/aria-activedescendant-has-tabindex`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md)
-- New rule: [`jsx-a11y/iframe-has-title`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/iframe-has-title.md)
-- New rule: [`jsx-a11y/interactive-supports-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md)
-- New rule: [`jsx-a11y/media-has-caption`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/media-has-caption.md) (disabled)
-- New rule: [`jsx-a11y/no-autofocus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md)
-- New rule: [`jsx-a11y/no-distracting-elements`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md)
-- New rule: [`jsx-a11y/no-interactive-element-to-noninteractive-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-interactive-element-to-noninteractive-role.md) (disabled)
-- New rule: [`jsx-a11y/no-noninteractive-element-interactions`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md)
-- New rule: [`jsx-a11y/no-noninteractive-element-to-interactive-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md)
-- New rule: [`jsx-a11y/no-noninteractive-tabindex`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-tabindex.md)
-- New rule: [`jsx-a11y/no-redundant-roles`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md)
-- New rule: [`lodash/prefer-some`](https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/prefer-some.md)
-- New rule: [`react/forbid-elements`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md) (disabled)
-- New rule: [`react/forbid-foreign-prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md)
-- New rule: [`react/no-will-update-set-state`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md)
-- New rule: [`react/void-dom-elements-no-children`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md)
-- New rule: [`no-await-in-loop`](http://eslint.org/docs/rules/no-await-in-loop)
-- New rule: [`prefer-promise-reject-errors`](http://eslint.org/docs/rules/prefer-promise-reject-errors)
-- New rule: [`require-await`](http://eslint.org/docs/rules/require-await)
-- New rule: [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring)
-- New rule: [`no-compare-neg-zero`](http://eslint.org/docs/rules/no-compare-neg-zero)
-- New rule: [`capitalized-comments`](http://eslint.org/docs/rules/capitalized-comments) (disabled)
-- New rule: [`no-multi-assign`](http://eslint.org/docs/rules/no-multi-assign)
-- New rule: [`nonblock-statement-body-position`](http://eslint.org/docs/rules/nonblock-statement-body-position) (disabled)
-- New rule: [`template-tag-spacing`](http://eslint.org/docs/rules/template-tag-spacing)
+
+* New rule:
+  [`babel/semi`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.0)
+* New rule:
+  [`flowtype/no-types-missing-file-annotation`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-no-types-missing-file-annotation)
+* New rule:
+  [`jsx-a11y/accessible-emoji`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md)
+* New rule:
+  [`jsx-a11y/alt-text`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md)
+* New rule:
+  [`jsx-a11y/aria-activedescendant-has-tabindex`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md)
+* New rule:
+  [`jsx-a11y/iframe-has-title`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/iframe-has-title.md)
+* New rule:
+  [`jsx-a11y/interactive-supports-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md)
+* New rule:
+  [`jsx-a11y/media-has-caption`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/media-has-caption.md)
+  (disabled)
+* New rule:
+  [`jsx-a11y/no-autofocus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md)
+* New rule:
+  [`jsx-a11y/no-distracting-elements`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md)
+* New rule:
+  [`jsx-a11y/no-interactive-element-to-noninteractive-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-interactive-element-to-noninteractive-role.md)
+  (disabled)
+* New rule:
+  [`jsx-a11y/no-noninteractive-element-interactions`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md)
+* New rule:
+  [`jsx-a11y/no-noninteractive-element-to-interactive-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md)
+* New rule:
+  [`jsx-a11y/no-noninteractive-tabindex`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-tabindex.md)
+* New rule:
+  [`jsx-a11y/no-redundant-roles`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md)
+* New rule:
+  [`lodash/prefer-some`](https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/prefer-some.md)
+* New rule:
+  [`react/forbid-elements`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md)
+  (disabled)
+* New rule:
+  [`react/forbid-foreign-prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md)
+* New rule:
+  [`react/no-will-update-set-state`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md)
+* New rule:
+  [`react/void-dom-elements-no-children`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md)
+* New rule: [`no-await-in-loop`](http://eslint.org/docs/rules/no-await-in-loop)
+* New rule:
+  [`prefer-promise-reject-errors`](http://eslint.org/docs/rules/prefer-promise-reject-errors)
+* New rule: [`require-await`](http://eslint.org/docs/rules/require-await)
+* New rule:
+  [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring)
+* New rule:
+  [`no-compare-neg-zero`](http://eslint.org/docs/rules/no-compare-neg-zero)
+* New rule:
+  [`capitalized-comments`](http://eslint.org/docs/rules/capitalized-comments)
+  (disabled)
+* New rule: [`no-multi-assign`](http://eslint.org/docs/rules/no-multi-assign)
+* New rule:
+  [`nonblock-statement-body-position`](http://eslint.org/docs/rules/nonblock-statement-body-position)
+  (disabled)
+* New rule:
+  [`template-tag-spacing`](http://eslint.org/docs/rules/template-tag-spacing)
 
 ### Removed
-- Deprecated: [`babel/no-await-in-loop`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.1)
-- Deprecated: [`jsx-a11y/img-has-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
-- Deprecated: [`jsx-a11y/onclick-has-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
-- Deprecated: [`jsx-a11y/onclick-has-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
-- Deprecated: [`jsx-a11y/jsx-space-before-closing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06)
 
+* Deprecated:
+  [`babel/no-await-in-loop`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.1)
+* Deprecated:
+  [`jsx-a11y/img-has-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
+* Deprecated:
+  [`jsx-a11y/onclick-has-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
+* Deprecated:
+  [`jsx-a11y/onclick-has-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
+* Deprecated:
+  [`jsx-a11y/jsx-space-before-closing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06)
 
 ## [15.2.0] - 2017-03-06
+
 ### Changed
-- `eslint` upgrade to `3.17.x`
+
+* `eslint` upgrade to `3.17.x`
 
 ## [15.1.2] - 2017-02-23
+
 ### Fixed
-- `jquery-dollar-sign-reference` now checks assignments from `LogicalExpression` / `BinaryExpression`
+
+* `jquery-dollar-sign-reference` now checks assignments from `LogicalExpression`
+  / `BinaryExpression`
 
 ## [15.1.1] - 2017-01-17
+
 ### Added
-- Added `eslint-index` package ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-- Added `rules-status` and `rules-omitted` scripts ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-- Added new `eslint-plugin-react` rules: `no-array-index-key`, `require-default-props` ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-- Added new `eslint-plugin-lodash` rules: `import-scope` ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-- Added new `eslint-plugin-promise` rules: `no-return-wrap`, `no-nesting`, `no-promise-in-callback`, `no-callback-in-promise`, `avoid-new`, `prefer-await-to-then`, `prefer-await-to-callbacks` ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+
+* Added `eslint-index` package
+  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+* Added `rules-status` and `rules-omitted` scripts
+  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+* Added new `eslint-plugin-react` rules: `no-array-index-key`,
+  `require-default-props`
+  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+* Added new `eslint-plugin-lodash` rules: `import-scope`
+  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+* Added new `eslint-plugin-promise` rules: `no-return-wrap`, `no-nesting`,
+  `no-promise-in-callback`, `no-callback-in-promise`, `avoid-new`,
+  `prefer-await-to-then`, `prefer-await-to-callbacks`
+  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
 ### Changed
-- Updated `eslint-plugin-flowtype`, `eslint-plugin-lodash`, `eslint-plugin-mocha`, `eslint-plugin-promise`, `eslint-plugin-react` to their latest versions ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-- Updated `react/prefer-stateless-function` rule to include `ignorePureComponents` flag ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+
+* Updated `eslint-plugin-flowtype`, `eslint-plugin-lodash`,
+  `eslint-plugin-mocha`, `eslint-plugin-promise`, `eslint-plugin-react` to their
+  latest versions
+  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+* Updated `react/prefer-stateless-function` rule to include
+  `ignorePureComponents` flag
+  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
 ### Removed
-- Removed `eslint-find-rules` package ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+
+* Removed `eslint-find-rules` package
+  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
 # Pre-15.1.1 Changelog
 
-Changes were originally tracked in Shopify's [JavaScript monorepo](https://github.com/Shopify/javascript/blob/f10bf7ddbdae07370cfe7c94617c450257731552/CHANGELOG.md).
+Changes were originally tracked in Shopify's
+[JavaScript monorepo](https://github.com/Shopify/javascript/blob/f10bf7ddbdae07370cfe7c94617c450257731552/CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,11 @@
 * Added a `typescript` and `typescript-react` config [[#54](https://github.com/Shopify/eslint-plugin-shopify/pull/54)]
 
 ### Changed
-
-* `plugin:shopify/prettier` will now enforce trailing commas in function
-  parameter calls
+* `plugin:shopify/prettier` will now enforce trailing commas in function parameter calls
 * `comma-dangle` will now enforce multi-line function parameters
-* Removed `plugin:shopify/esnext` as an included extension of the
-  `plugin:shopify/prettier` config. `plugin:shopify/esnext` must now be extended
-  by the consumer to use the `plugin:shopify/prettier`.
+* Removed `plugin:shopify/esnext` as an included extension of the `plugin:shopify/prettier` config. `plugin:shopify/esnext` must now be extended by the consumer to use the `plugin:shopify/prettier`.
 
   Example (`package.json`):
-
   ```
   "eslintConfig": {
     "extends": [
@@ -26,26 +21,18 @@
   ```
 
 ## [18.0.0] - 2017-10-31
-
 ### Changed
-
 * Turned off `class-methods-use-this`
 
 ## [17.2.1] - 2017-10-30
-
 ### Changed
-
 * Turned off `babel/semi` rule in prettier config
 
 ## [17.2.0] - 2017-10-25
-
 ### Added
-
-* Added a prettier config
-  [[#46](https://github.com/Shopify/eslint-plugin-shopify/pull/46)]
+* Added a prettier config [[#46](https://github.com/Shopify/eslint-plugin-shopify/pull/46)]
 
 Example:
-
 ```
 "eslintConfig": {
   "extends": [
@@ -55,208 +42,132 @@ Example:
 ```
 
 ### Changed
-
-* Replace all `warn` with `error`
-  [[#48](https://github.com/Shopify/eslint-plugin-shopify/pull/48)]
-* `space-before-function-paren` now uses `asyncArrow` option (eg. `async () =>
-  {}`) [[#43](https://github.com/Shopify/eslint-plugin-shopify/pull/43)]
-* Enable `padding-line-between-statements` for directives.
-  [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
+* Replace all `warn` with `error` [[#48](https://github.com/Shopify/eslint-plugin-shopify/pull/48)]
+* `space-before-function-paren` now uses `asyncArrow` option (eg. `async () => {}`) [[#43](https://github.com/Shopify/eslint-plugin-shopify/pull/43)]
+* Enable `padding-line-between-statements` for directives.  [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
 ### Removed
+* `lines-around-directive` was deprecated in ESLint `v4.0.0`. [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
-* `lines-around-directive` was deprecated in ESLint `v4.0.0`.
-  [[#44](https://github.com/Shopify/eslint-plugin-shopify/pull/44)]
 
 ## [17.1.0] - 2017-09-19
 
 ### Added
-
 * New rules ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
-  * `import/no-anonymous-default-export`
-  * `jsx-a11y/anchor-is-valid`
-  * `no-buffer-constructor`
-  * `node/no-extraneous-import` (disabled)
-  * `node/no-extraneous-require`
-  * `for-direction`
-  * `getter-return`
-  * `react/boolean-prop-naming` (disabled)
-  * `react/default-props-match-prop-types`
-  * `react/no-redundant-should-component-update`
-  * `react/no-typos`
-  * `react/no-unused-state`
-  * `react/jsx-closing-tag-location`
-  * `array-bracket-newline` (disabled)
-  * `array-element-newline` (disabled)
-  * `function-paren-newline`
-  * `padding-line-between-statements` (disabled)
-  * `semi-style`
-  * `switch-colon-spacing`
+  - `import/no-anonymous-default-export`
+  - `jsx-a11y/anchor-is-valid`
+  - `no-buffer-constructor`
+  - `node/no-extraneous-import` (disabled)
+  - `node/no-extraneous-require`
+  - `for-direction`
+  - `getter-return`
+  - `react/boolean-prop-naming` (disabled)
+  - `react/default-props-match-prop-types`
+  - `react/no-redundant-should-component-update`
+  - `react/no-typos`
+  - `react/no-unused-state`
+  - `react/jsx-closing-tag-location`
+  - `array-bracket-newline` (disabled)
+  - `array-element-newline` (disabled)
+  - `function-paren-newline`
+  - `padding-line-between-statements` (disabled)
+  - `semi-style`
+  - `switch-colon-spacing`
+
 
 ### Changed
-
-* Updated dependencies
-  ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
-  * `eslint`
-  * `babel-eslint`
-  * `eslint-plugin-import`
-  * `eslint-plugin-jsx-a11y`
-  * `eslint-plugin-node`
-  * `eslint-plugin-react`
-* `jquery-dollar-sign-reference` no longer flags assignments from `await`
-  expressions
+- Updated dependencies ([#41](https://github.com/Shopify/eslint-plugin-shopify/pull/41)):
+  - `eslint`
+  - `babel-eslint`
+  - `eslint-plugin-import`
+  - `eslint-plugin-jsx-a11y`
+  - `eslint-plugin-node`
+  - `eslint-plugin-react`
+- `jquery-dollar-sign-reference` no longer flags assignments from `await` expressions
 
 ### Removed
-
-* `jsx-a11y/href-no-hash` replaced with `jsx-a11y/anchor-is-valid`
+- `jsx-a11y/href-no-hash` replaced with `jsx-a11y/anchor-is-valid`
 
 ## [17.0.0] - 2017-08-17
-
 ### Changed
+- `eslint` upgrade to `4.3.0`
+- `node.js` minimum supported node version update to `6.11.1` (LTS).
+- Update dependencies:
+  - `eslint-plugin-ava`: `^4.2.0` → `^4.2.1`.
+  - `eslint-plugin-babel`: `^4.1.1` → `^4.1.2`.
+  - `eslint-plugin-lodash`: `^2.4.2` → `^2.4.4`.
+  - `eslint-plugin-mocha`: `^4.9.0` → `^4.11.0`.
+  - `eslint-plugin-node`: `^4.2.2` → `^4.2.3`.
+  - `eslint-plugin-react`: `^7.0.0` → `^7.0.1`.
 
-* `eslint` upgrade to `4.3.0`
-* `node.js` minimum supported node version update to `6.11.1` (LTS).
-* Update dependencies:
-  * `eslint-plugin-ava`: `^4.2.0` → `^4.2.1`.
-  * `eslint-plugin-babel`: `^4.1.1` → `^4.1.2`.
-  * `eslint-plugin-lodash`: `^2.4.2` → `^2.4.4`.
-  * `eslint-plugin-mocha`: `^4.9.0` → `^4.11.0`.
-  * `eslint-plugin-node`: `^4.2.2` → `^4.2.3`.
-  * `eslint-plugin-react`: `^7.0.0` → `^7.0.1`.
 
 ## [16.0.1] - 2017-05-29
-
 ### Changed
-
-* Turned off
-  [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring)
-  ([#30](https://github.com/Shopify/eslint-plugin-shopify/pull/30))
+- Turned off [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring) ([#30](https://github.com/Shopify/eslint-plugin-shopify/pull/30))
 
 ## [16.0.0] - 2017-05-16
-
 ### Added
-
-* New rule:
-  [`babel/semi`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.0)
-* New rule:
-  [`flowtype/no-types-missing-file-annotation`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-no-types-missing-file-annotation)
-* New rule:
-  [`jsx-a11y/accessible-emoji`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md)
-* New rule:
-  [`jsx-a11y/alt-text`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md)
-* New rule:
-  [`jsx-a11y/aria-activedescendant-has-tabindex`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md)
-* New rule:
-  [`jsx-a11y/iframe-has-title`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/iframe-has-title.md)
-* New rule:
-  [`jsx-a11y/interactive-supports-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md)
-* New rule:
-  [`jsx-a11y/media-has-caption`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/media-has-caption.md)
-  (disabled)
-* New rule:
-  [`jsx-a11y/no-autofocus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md)
-* New rule:
-  [`jsx-a11y/no-distracting-elements`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md)
-* New rule:
-  [`jsx-a11y/no-interactive-element-to-noninteractive-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-interactive-element-to-noninteractive-role.md)
-  (disabled)
-* New rule:
-  [`jsx-a11y/no-noninteractive-element-interactions`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md)
-* New rule:
-  [`jsx-a11y/no-noninteractive-element-to-interactive-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md)
-* New rule:
-  [`jsx-a11y/no-noninteractive-tabindex`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-tabindex.md)
-* New rule:
-  [`jsx-a11y/no-redundant-roles`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md)
-* New rule:
-  [`lodash/prefer-some`](https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/prefer-some.md)
-* New rule:
-  [`react/forbid-elements`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md)
-  (disabled)
-* New rule:
-  [`react/forbid-foreign-prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md)
-* New rule:
-  [`react/no-will-update-set-state`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md)
-* New rule:
-  [`react/void-dom-elements-no-children`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md)
-* New rule: [`no-await-in-loop`](http://eslint.org/docs/rules/no-await-in-loop)
-* New rule:
-  [`prefer-promise-reject-errors`](http://eslint.org/docs/rules/prefer-promise-reject-errors)
-* New rule: [`require-await`](http://eslint.org/docs/rules/require-await)
-* New rule:
-  [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring)
-* New rule:
-  [`no-compare-neg-zero`](http://eslint.org/docs/rules/no-compare-neg-zero)
-* New rule:
-  [`capitalized-comments`](http://eslint.org/docs/rules/capitalized-comments)
-  (disabled)
-* New rule: [`no-multi-assign`](http://eslint.org/docs/rules/no-multi-assign)
-* New rule:
-  [`nonblock-statement-body-position`](http://eslint.org/docs/rules/nonblock-statement-body-position)
-  (disabled)
-* New rule:
-  [`template-tag-spacing`](http://eslint.org/docs/rules/template-tag-spacing)
+- New rule: [`babel/semi`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.0)
+- New rule: [`flowtype/no-types-missing-file-annotation`](https://github.com/gajus/eslint-plugin-flowtype#eslint-plugin-flowtype-rules-no-types-missing-file-annotation)
+- New rule: [`jsx-a11y/accessible-emoji`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/accessible-emoji.md)
+- New rule: [`jsx-a11y/alt-text`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/alt-text.md)
+- New rule: [`jsx-a11y/aria-activedescendant-has-tabindex`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/aria-activedescendant-has-tabindex.md)
+- New rule: [`jsx-a11y/iframe-has-title`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/iframe-has-title.md)
+- New rule: [`jsx-a11y/interactive-supports-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/interactive-supports-focus.md)
+- New rule: [`jsx-a11y/media-has-caption`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/media-has-caption.md) (disabled)
+- New rule: [`jsx-a11y/no-autofocus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-autofocus.md)
+- New rule: [`jsx-a11y/no-distracting-elements`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-distracting-elements.md)
+- New rule: [`jsx-a11y/no-interactive-element-to-noninteractive-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-interactive-element-to-noninteractive-role.md) (disabled)
+- New rule: [`jsx-a11y/no-noninteractive-element-interactions`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-interactions.md)
+- New rule: [`jsx-a11y/no-noninteractive-element-to-interactive-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-element-to-interactive-role.md)
+- New rule: [`jsx-a11y/no-noninteractive-tabindex`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-noninteractive-tabindex.md)
+- New rule: [`jsx-a11y/no-redundant-roles`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-redundant-roles.md)
+- New rule: [`lodash/prefer-some`](https://github.com/wix/eslint-plugin-lodash/blob/master/docs/rules/prefer-some.md)
+- New rule: [`react/forbid-elements`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md) (disabled)
+- New rule: [`react/forbid-foreign-prop-types`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/forbid-foreign-prop-types.md)
+- New rule: [`react/no-will-update-set-state`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-will-update-set-state.md)
+- New rule: [`react/void-dom-elements-no-children`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/void-dom-elements-no-children.md)
+- New rule: [`no-await-in-loop`](http://eslint.org/docs/rules/no-await-in-loop)
+- New rule: [`prefer-promise-reject-errors`](http://eslint.org/docs/rules/prefer-promise-reject-errors)
+- New rule: [`require-await`](http://eslint.org/docs/rules/require-await)
+- New rule: [`prefer-destructuring`](http://eslint.org/docs/rules/prefer-destructuring)
+- New rule: [`no-compare-neg-zero`](http://eslint.org/docs/rules/no-compare-neg-zero)
+- New rule: [`capitalized-comments`](http://eslint.org/docs/rules/capitalized-comments) (disabled)
+- New rule: [`no-multi-assign`](http://eslint.org/docs/rules/no-multi-assign)
+- New rule: [`nonblock-statement-body-position`](http://eslint.org/docs/rules/nonblock-statement-body-position) (disabled)
+- New rule: [`template-tag-spacing`](http://eslint.org/docs/rules/template-tag-spacing)
 
 ### Removed
+- Deprecated: [`babel/no-await-in-loop`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.1)
+- Deprecated: [`jsx-a11y/img-has-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
+- Deprecated: [`jsx-a11y/onclick-has-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
+- Deprecated: [`jsx-a11y/onclick-has-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
+- Deprecated: [`jsx-a11y/jsx-space-before-closing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06)
 
-* Deprecated:
-  [`babel/no-await-in-loop`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.1.1)
-* Deprecated:
-  [`jsx-a11y/img-has-alt`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
-* Deprecated:
-  [`jsx-a11y/onclick-has-focus`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
-* Deprecated:
-  [`jsx-a11y/onclick-has-role`](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/CHANGELOG.md#500--2017-05-05)
-* Deprecated:
-  [`jsx-a11y/jsx-space-before-closing`](https://github.com/yannickcr/eslint-plugin-react/blob/master/CHANGELOG.md#700---2017-05-06)
 
 ## [15.2.0] - 2017-03-06
-
 ### Changed
-
-* `eslint` upgrade to `3.17.x`
+- `eslint` upgrade to `3.17.x`
 
 ## [15.1.2] - 2017-02-23
-
 ### Fixed
-
-* `jquery-dollar-sign-reference` now checks assignments from `LogicalExpression`
-  / `BinaryExpression`
+- `jquery-dollar-sign-reference` now checks assignments from `LogicalExpression` / `BinaryExpression`
 
 ## [15.1.1] - 2017-01-17
-
 ### Added
-
-* Added `eslint-index` package
-  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-* Added `rules-status` and `rules-omitted` scripts
-  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-* Added new `eslint-plugin-react` rules: `no-array-index-key`,
-  `require-default-props`
-  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-* Added new `eslint-plugin-lodash` rules: `import-scope`
-  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-* Added new `eslint-plugin-promise` rules: `no-return-wrap`, `no-nesting`,
-  `no-promise-in-callback`, `no-callback-in-promise`, `avoid-new`,
-  `prefer-await-to-then`, `prefer-await-to-callbacks`
-  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+- Added `eslint-index` package ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+- Added `rules-status` and `rules-omitted` scripts ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+- Added new `eslint-plugin-react` rules: `no-array-index-key`, `require-default-props` ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+- Added new `eslint-plugin-lodash` rules: `import-scope` ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+- Added new `eslint-plugin-promise` rules: `no-return-wrap`, `no-nesting`, `no-promise-in-callback`, `no-callback-in-promise`, `avoid-new`, `prefer-await-to-then`, `prefer-await-to-callbacks` ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
 ### Changed
-
-* Updated `eslint-plugin-flowtype`, `eslint-plugin-lodash`,
-  `eslint-plugin-mocha`, `eslint-plugin-promise`, `eslint-plugin-react` to their
-  latest versions
-  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
-* Updated `react/prefer-stateless-function` rule to include
-  `ignorePureComponents` flag
-  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+- Updated `eslint-plugin-flowtype`, `eslint-plugin-lodash`, `eslint-plugin-mocha`, `eslint-plugin-promise`, `eslint-plugin-react` to their latest versions ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+- Updated `react/prefer-stateless-function` rule to include `ignorePureComponents` flag ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
 ### Removed
-
-* Removed `eslint-find-rules` package
-  ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
+- Removed `eslint-find-rules` package ([#4](https://github.com/Shopify/eslint-plugin-shopify/pull/4))
 
 # Pre-15.1.1 Changelog
 
-Changes were originally tracked in Shopify's
-[JavaScript monorepo](https://github.com/Shopify/javascript/blob/f10bf7ddbdae07370cfe7c94617c450257731552/CHANGELOG.md).
+Changes were originally tracked in Shopify's [JavaScript monorepo](https://github.com/Shopify/javascript/blob/f10bf7ddbdae07370cfe7c94617c450257731552/CHANGELOG.md).

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   environment:
     PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/node_modules/.bin"
   node:
-    version: 6.11.1
+    version: 8.9.1
 
 dependencies:
   override:

--- a/lib/config/all.js
+++ b/lib/config/all.js
@@ -61,6 +61,6 @@ module.exports = {
     require('./rules/shopify'),
     require('./rules/sort-class-members'),
     require('./rules/typescript'),
-    require('./rules/typescript-react')
+    require('./rules/typescript-react'),
   ),
 };

--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -16,6 +16,6 @@ module.exports = {
     require('./rules/shopify'),
     require('./rules/strict-mode'),
     require('./rules/stylistic-issues'),
-    require('./rules/variables')
+    require('./rules/variables'),
   ),
 };

--- a/lib/config/esnext.js
+++ b/lib/config/esnext.js
@@ -36,6 +36,6 @@ module.exports = {
       'no-await-in-loop': 'off',
       'object-curly-spacing': 'off',
       'no-invalid-this': 'off',
-    }
+    },
   ),
 };

--- a/lib/config/prettier.js
+++ b/lib/config/prettier.js
@@ -8,7 +8,7 @@ module.exports = {
       'error',
       {
         singleQuote: true,
-        trailingComma: 'es5',
+        trailingComma: 'all',
         bracketSpacing: false,
         jsxBracketSameLine: false,
       },

--- a/lib/config/rules/possible-errors.js
+++ b/lib/config/rules/possible-errors.js
@@ -10,7 +10,16 @@ module.exports = {
   // Disallow comparing against -0
   'no-compare-neg-zero': 'error',
   // Disallow or enforce trailing commas
-  'comma-dangle': ['error', 'always-multiline'],
+  'comma-dangle': [
+    'error',
+    {
+      arrays: 'always-multiline',
+      objects: 'always-multiline',
+      imports: 'always-multiline',
+      exports: 'always-multiline',
+      functions: 'always-multiline',
+    },
+  ],
   // Disallow assignment in conditional expressions
   'no-cond-assign': 'error',
   // Disallow use of console

--- a/lib/rules/jquery-dollar-sign-reference.js
+++ b/lib/rules/jquery-dollar-sign-reference.js
@@ -132,7 +132,7 @@ module.exports = {
 
         const checkDescriptor = Object.getOwnPropertyDescriptor(
           nonChainingMethods,
-          prop
+          prop,
         );
         const check = checkDescriptor && checkDescriptor.value;
         if (
@@ -193,7 +193,7 @@ module.exports = {
       if (isjQueryRef && hasRegularValue) {
         context.report(
           node,
-          'Don’t use a $-prefixed identifier for a non-jQuery value.'
+          'Don’t use a $-prefixed identifier for a non-jQuery value.',
         );
       } else if (!isjQueryRef && hasDefinitejQueryValue) {
         context.report(node, 'Use a $-prefixed identifier for a jQuery value.');
@@ -214,7 +214,7 @@ module.exports = {
       checkForValidjQueryReference(
         node,
         node.id,
-        getFinalAssignmentValue(node.init)
+        getFinalAssignmentValue(node.init),
       );
     }
 
@@ -226,7 +226,7 @@ module.exports = {
       checkForValidjQueryReference(
         node,
         node.left,
-        getFinalAssignmentValue(node.right)
+        getFinalAssignmentValue(node.right),
       );
     }
 

--- a/lib/rules/prefer-class-properties.js
+++ b/lib/rules/prefer-class-properties.js
@@ -86,7 +86,7 @@ module.exports = {
         }
 
         getTopLevelThisAssignmentExpressions(constructor.value).forEach(
-          checkConstructorThisAssignment
+          checkConstructorThisAssignment,
         );
       } else {
         getClassInstanceProperties(node).forEach(propertyNode => {

--- a/lib/rules/prefer-early-return.js
+++ b/lib/rules/prefer-early-return.js
@@ -56,7 +56,7 @@ module.exports = {
       if (hasSimplifiableConditionalBody(body)) {
         context.report(
           body,
-          'Prefer an early return to a conditionally-wrapped function body'
+          'Prefer an early return to a conditionally-wrapped function body',
         );
       }
     }

--- a/lib/rules/prefer-twine.js
+++ b/lib/rules/prefer-twine.js
@@ -16,7 +16,7 @@ module.exports = {
           if (specifier.local.name !== 'Twine') {
             context.report(
               node,
-              'You should use "Twine" as the reference name when importing twine.'
+              'You should use "Twine" as the reference name when importing twine.',
             );
           }
         });

--- a/tests/lib/rules/binary-assignment-parens.js
+++ b/tests/lib/rules/binary-assignment-parens.js
@@ -16,7 +16,7 @@ const validNonBooleanExamples = [].concat(
     {code: `var foo = ( 'bar' ${operator} 'baz' );`, options: ['never']},
     {code: `var foo; foo = 'bar' ${operator} 'baz';`},
     {code: `var foo; foo = ('bar' ${operator} 'baz');`, options: ['never']},
-  ])
+  ]),
 );
 
 const validBooleanExamples = [].concat(
@@ -27,7 +27,7 @@ const validBooleanExamples = [].concat(
     {code: `var foo; foo = ('bar' ${operator} 'baz')`},
     {code: `var foo; foo = ( 'bar' ${operator} 'baz' )`},
     {code: `var foo; foo = 'bar' ${operator} 'baz'`, options: ['never']},
-  ])
+  ]),
 );
 
 const validLogicalExamples = [
@@ -149,7 +149,7 @@ const invalidBooleanExamples = [].concat(
         },
       ],
     },
-  ])
+  ]),
 );
 
 function errors(count, needsParens) {
@@ -261,7 +261,7 @@ ruleTester.run('binary-assignment-parens', rule, {
   valid: [].concat(
     validNonBooleanExamples,
     validBooleanExamples,
-    validLogicalExamples
+    validLogicalExamples,
   ),
   invalid: [].concat(invalidBooleanExamples, invalidLogicalExamples),
 });


### PR DESCRIPTION
* `comma-dangle` will now enforce trailing commas in multi-line function calls via the `esnext` config. This was previously enforced through our babel config ([`babel/func-params-comma-dangle`](https://github.com/babel/eslint-plugin-babel/releases/tag/v4.0.0)) but the rule has been deprecated. We never updated the eslint `comma-dangle` to reflect the deprecation.

* the `trailingComma` setting in our `prettier` config has also been updated the `trailingComma` option to `all`. This will also enforce trailing commas in multiline function calls

* Added a `.prettierrc` file to the project so maintainers can get prettier formatting via editor plugins