### PR TITLE
Replace no-debugger with shopify/no-debugger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- ## Unreleased -->
 
+
+## [18.3.0] - 2017-12-18
+
+### Added
+* Added `shopify/no-debugger`, which behaves the same as ESLint's `no-debugger` but without a fixer.
+
 ## [18.2.0] - 2017-12-04
 ### Added
 * Added a `typescript-prettier` config to run prettier against typescript projects.
@@ -178,7 +184,8 @@ Example:
 
 Changes were originally tracked in Shopify's [JavaScript monorepo](https://github.com/Shopify/javascript/blob/f10bf7ddbdae07370cfe7c94617c450257731552/CHANGELOG.md).
 
-[Unreleased]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.2.0...HEAD
+[Unreleased]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.3.0...HEAD
+[18.3.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.2.0...v18.3.0
 [18.2.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.1.0...v18.2.0
 [18.1.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v18.0.0...v18.1.0
 [18.0.0]: https://github.com/Shopify/eslint-plugin-shopify/compare/v17.2.1...v18.0.0

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
     'binary-assignment-parens': require('./lib/rules/binary-assignment-parens'),
     'class-property-semi': require('./lib/rules/class-property-semi'),
     'jquery-dollar-sign-reference': require('./lib/rules/jquery-dollar-sign-reference'),
+    'no-debugger': require('./lib/rules/no-debugger'),
     'no-useless-computed-properties': require('./lib/rules/no-useless-computed-properties'),
     'no-fully-static-classes': require('./lib/rules/no-fully-static-classes'),
     'prefer-class-properties': require('./lib/rules/prefer-class-properties'),

--- a/lib/config/rules/possible-errors.js
+++ b/lib/config/rules/possible-errors.js
@@ -29,7 +29,7 @@ module.exports = {
   // Disallow control characters in regular expressions
   'no-control-regex': 'error',
   // Disallow use of debugger
-  'no-debugger': 'error',
+  'no-debugger': 'off',
   // Disallow duplicate arguments in functions
   'no-dupe-args': 'error',
   // Disallow duplicate keys when creating object literals

--- a/lib/config/rules/shopify.js
+++ b/lib/config/rules/shopify.js
@@ -5,6 +5,8 @@ module.exports = {
   'shopify/class-property-semi': 'error',
   // Requires that all jQuery objects are assigned to references prefixed with `$`.
   'shopify/jquery-dollar-sign-reference': 'off',
+  // disallow the use of debugger (without fixer to prevent autofix on save in editors)
+  'shopify/no-debugger': 'error',
   // Prevents the usage of unnecessary computed properties.
   'shopify/no-useless-computed-properties': 'error',
   // Prevents the declaration of classes consisting only of static members.

--- a/lib/rules/no-debugger.js
+++ b/lib/rules/no-debugger.js
@@ -1,0 +1,21 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'disallow the use of `debugger`',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      DebuggerStatement(node) {
+        context.report({
+          node,
+          message: "Unexpected 'debugger' statement.",
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
Addresses https://github.com/Shopify/sewing-kit/issues/460

Tested this in `web` via `yarn link eslint-plugin-shopify`. Autofix behaved as expected. 