### PR TITLE
Update codebase to use es5 trailingComma

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
   "singleQuote": true,
   "bracketSpacing": false,
-  "trailingComma": "all"
+  "trailingComma": "es5"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-<!-- ## Unreleased -->
+## Unreleased
 
+### Changed
+* Changed `eslint-config-shopify` codebase to follow es5 trailingComma [[#61](https://github.com/Shopify/eslint-plugin-shopify/pull/61)]
 
 ## [18.3.0] - 2017-12-18
 

--- a/lib/config/all.js
+++ b/lib/config/all.js
@@ -63,6 +63,6 @@ module.exports = {
     require('./rules/sort-class-members'),
     require('./rules/typescript'),
     require('./rules/typescript-prettier'),
-    require('./rules/typescript-react'),
+    require('./rules/typescript-react')
   ),
 };

--- a/lib/config/core.js
+++ b/lib/config/core.js
@@ -16,6 +16,6 @@ module.exports = {
     require('./rules/shopify'),
     require('./rules/strict-mode'),
     require('./rules/stylistic-issues'),
-    require('./rules/variables'),
+    require('./rules/variables')
   ),
 };

--- a/lib/config/esnext.js
+++ b/lib/config/esnext.js
@@ -36,6 +36,6 @@ module.exports = {
       'no-await-in-loop': 'off',
       'object-curly-spacing': 'off',
       'no-invalid-this': 'off',
-    },
+    }
   ),
 };

--- a/lib/rules/jquery-dollar-sign-reference.js
+++ b/lib/rules/jquery-dollar-sign-reference.js
@@ -132,7 +132,7 @@ module.exports = {
 
         const checkDescriptor = Object.getOwnPropertyDescriptor(
           nonChainingMethods,
-          prop,
+          prop
         );
         const check = checkDescriptor && checkDescriptor.value;
         if (
@@ -193,7 +193,7 @@ module.exports = {
       if (isjQueryRef && hasRegularValue) {
         context.report(
           node,
-          'Don’t use a $-prefixed identifier for a non-jQuery value.',
+          'Don’t use a $-prefixed identifier for a non-jQuery value.'
         );
       } else if (!isjQueryRef && hasDefinitejQueryValue) {
         context.report(node, 'Use a $-prefixed identifier for a jQuery value.');
@@ -214,7 +214,7 @@ module.exports = {
       checkForValidjQueryReference(
         node,
         node.id,
-        getFinalAssignmentValue(node.init),
+        getFinalAssignmentValue(node.init)
       );
     }
 
@@ -226,7 +226,7 @@ module.exports = {
       checkForValidjQueryReference(
         node,
         node.left,
-        getFinalAssignmentValue(node.right),
+        getFinalAssignmentValue(node.right)
       );
     }
 

--- a/lib/rules/prefer-class-properties.js
+++ b/lib/rules/prefer-class-properties.js
@@ -86,7 +86,7 @@ module.exports = {
         }
 
         getTopLevelThisAssignmentExpressions(constructor.value).forEach(
-          checkConstructorThisAssignment,
+          checkConstructorThisAssignment
         );
       } else {
         getClassInstanceProperties(node).forEach(propertyNode => {

--- a/lib/rules/prefer-early-return.js
+++ b/lib/rules/prefer-early-return.js
@@ -56,7 +56,7 @@ module.exports = {
       if (hasSimplifiableConditionalBody(body)) {
         context.report(
           body,
-          'Prefer an early return to a conditionally-wrapped function body',
+          'Prefer an early return to a conditionally-wrapped function body'
         );
       }
     }

--- a/lib/rules/prefer-twine.js
+++ b/lib/rules/prefer-twine.js
@@ -16,7 +16,7 @@ module.exports = {
           if (specifier.local.name !== 'Twine') {
             context.report(
               node,
-              'You should use "Twine" as the reference name when importing twine.',
+              'You should use "Twine" as the reference name when importing twine.'
             );
           }
         });

--- a/lib/rules/restrict-full-import.js
+++ b/lib/rules/restrict-full-import.js
@@ -24,6 +24,7 @@ module.exports = {
     /* eslint-disable prettier/prettier */
     // https://github.com/prettier/eslint-plugin-prettier/issues/65
     function isPotentiallyProblematicLeft(left) {
+      // prettier-ignore
       return left.type === 'Identifier' ||
       (
         left.type === 'ObjectPattern' && left.properties.some((prop) => {
@@ -71,7 +72,7 @@ module.exports = {
               ? specifiers.find(isFullImportSpecifier)
               : node,
           // prettier-ignore
-          message: `Unexpected full import of restricted module '${node.source.value}'.`
+          message: `Unexpected full import of restricted module '${node.source.value}'.`,
         });
       }
     }
@@ -84,7 +85,7 @@ module.exports = {
         context.report({
           node,
           // prettier-ignore
-          message: `Unexpected full import of restricted module '${right.arguments[0].value}'.`
+          message: `Unexpected full import of restricted module '${right.arguments[0].value}'.`,
         });
       }
     }

--- a/lib/rules/restrict-full-import.js
+++ b/lib/rules/restrict-full-import.js
@@ -71,7 +71,7 @@ module.exports = {
               ? specifiers.find(isFullImportSpecifier)
               : node,
           // prettier-ignore
-          message: `Unexpected full import of restricted module '${node.source.value}'.`,
+          message: `Unexpected full import of restricted module '${node.source.value}'.`
         });
       }
     }
@@ -84,7 +84,7 @@ module.exports = {
         context.report({
           node,
           // prettier-ignore
-          message: `Unexpected full import of restricted module '${right.arguments[0].value}'.`,
+          message: `Unexpected full import of restricted module '${right.arguments[0].value}'.`
         });
       }
     }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,18 @@
       "plugin:shopify/node",
       "plugin:shopify/esnext",
       "plugin:shopify/prettier"
-    ]
+    ],
+    "rules": {
+      "prettier/prettier": [
+        "error",
+        {
+          "singleQuote": true,
+          "trailingComma": "es5",
+          "bracketSpacing": false,
+          "jsxBracketSameLine": false
+        }
+      ]
+    }
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-shopify",
-  "version": "18.3.0",
+  "version": "18.3.1-alpha.1",
   "description": "Shopify’s ESLint rules and configs.",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-shopify",
-  "version": "18.3.1-alpha.1",
+  "version": "18.3.0",
   "description": "Shopify’s ESLint rules and configs.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
* Format project codebase to use `es5` style for trailing comma so we don't break projects that are on node version 6 😥 
