### PR TITLE
Rule: `no-unnamed-dynamic-imports`; plugin: `webpack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - `jest/prefer-to-be-null`
   - `jest/prefer-to-be-undefined`
   - `jest/valid-expect`
+* Added `shopify/webpack` plugin
+* Added `shopify/webpack/no-unnamed-dynamic-imports` rule
 
 ## [18.3.1] - 2017-12-21
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ This plugin also provides the following tool-specific configurations, which can 
 - [jquery](lib/config/jquery.js): Use this for projects that use [jQuery](http://jquery.com).
 - [prettier](lib/config/prettier.js): Use [prettier](https://github.com/prettier/prettier) for consistent formatting. Extending this Shopify's prettier config will [override](https://github.com/prettier/eslint-config-prettier/blob/master/index.js) the default Shopify eslint rules in favor of prettier formatting.
 - [typescript-prettier](lib/config/typescript-prettier.js): Use [prettier](https://github.com/prettier/prettier) on typescript projects.
+- [webpack](lib/config/webpack.js): Use this for projects built by [webpack](https://webpack.js.org/).
 
 ### node
 
@@ -121,6 +122,7 @@ This plugin provides the following custom rules, which are included as appropria
 - [restrict-full-import](docs/rules/restrict-full-import.md): Prevents importing the entirety of a package.
 - [sinon-no-restricted-features](docs/rules/sinon-no-restricted-features.md): Restricts the use of specified sinon features.
 - [sinon-prefer-meaningful-assertions](docs/rules/sinon-prefer-meaningful-assertions.md): Requires the use of meaningful sinon assertions through sinon.assert or sinon-chai.
+- [webpack/no-unnamed-dynamic-imports](docs/rules/webpack/no-unnamed-dynamic-imports.md): Requires that all dynamic imports contain a `webpackChunkName` comment.
 
 ## Creating New Rules
 

--- a/docs/rules/webpack/no-unnamed-dynamic-imports.md
+++ b/docs/rules/webpack/no-unnamed-dynamic-imports.md
@@ -1,0 +1,45 @@
+# Enforces named dynamic webpack chunks. (`shopify/webpack/no-unnamed-dynamic-imports`)
+
+Omiting a dynamic import's `webpackChunkName` leads to hashed JavaScript filenames being deployed to production servers.  Including a human-readable fragment in filenames makes stack traces more readable, and improves triage accuracy.
+
+## Rule Details
+
+This rule mandates a `webpackChunkName` block comment for all `import` and `System.import` calls.
+
+The following patterns are considered warnings:
+
+```js
+async function foo() {
+  return import('bar');
+}
+
+async function car() {
+  return System.import('qux');
+}
+
+async function baz() {
+  return import(
+    // webpackChunkName: "foobar"
+    'foobar'
+  );
+}
+```
+
+The following patterns are not warnings:
+
+```js
+async function foo() {
+  return import(/* webpackChunkName: 'bar' */ 'bar');
+}
+
+async function car() {
+  return System.import(
+    /* webpackChunkName: "qux" */
+    'qux'
+  );
+}
+```
+
+## When Not To Use It
+
+If you do not want to enforce named chunks, you can safely disable this rule.

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     'restrict-full-import': require('./lib/rules/restrict-full-import'),
     'sinon-no-restricted-features': require('./lib/rules/sinon-no-restricted-features'),
     'sinon-prefer-meaningful-assertions': require('./lib/rules/sinon-prefer-meaningful-assertions'),
+    'webpack/no-unnamed-dynamic-imports': require('./lib/rules/webpack/no-unnamed-dynamic-imports'),
   },
 
   configs: {
@@ -30,5 +31,6 @@ module.exports = {
     typescript: require('./lib/config/typescript'),
     'typescript-prettier': require('./lib/config/typescript-prettier'),
     'typescript-react': require('./lib/config/typescript-react'),
+    webpack: require('./lib/config/webpack'),
   },
 };

--- a/lib/config/all.js
+++ b/lib/config/all.js
@@ -37,6 +37,7 @@ module.exports = {
     'typescript',
     'typescript-prettier',
     'typescript-react',
+    'webpack',
   ],
 
   rules: merge(
@@ -65,6 +66,7 @@ module.exports = {
     require('./rules/sort-class-members'),
     require('./rules/typescript'),
     require('./rules/typescript-prettier'),
-    require('./rules/typescript-react')
+    require('./rules/typescript-react'),
+    require('./rules/webpack')
   ),
 };

--- a/lib/config/rules/shopify.js
+++ b/lib/config/rules/shopify.js
@@ -23,4 +23,6 @@ module.exports = {
   'shopify/sinon-no-restricted-features': 'off',
   // Requires the use of meaningful sinon assertions through sinon.assert or sinon-chai.
   'shopify/sinon-prefer-meaningful-assertions': 'off',
+  // Requires that all dynamic imports contain a `webpackChunkName` comment.
+  'shopify/webpack/no-unnamed-dynamic-imports': 'off',
 };

--- a/lib/config/webpack.js
+++ b/lib/config/webpack.js
@@ -1,0 +1,6 @@
+module.exports = {
+  rules: {
+    // Requires that all dynamic imports contain a `webpackChunkName` comment.
+    'shopify/webpack/no-unnamed-dynamic-imports': 'error',
+  },
+};

--- a/lib/rules/webpack/no-unnamed-dynamic-imports.js
+++ b/lib/rules/webpack/no-unnamed-dynamic-imports.js
@@ -1,0 +1,63 @@
+function isDynamicImport(node) {
+  if (node.type !== 'CallExpression') {
+    return false;
+  }
+
+  const {callee} = node;
+  if (callee.type === 'Import') {
+    return true;
+  }
+
+  return (
+    callee.type === 'MemberExpression' &&
+    callee.object.name === 'System' &&
+    callee.property.name === 'import' &&
+    node.arguments.length === 1
+  );
+}
+
+function isChunkNameComment(comment) {
+  return comment.value.match(/\bwebpackChunkName: ["'].+["']/);
+}
+
+function hasLineChunkNameComment(comments) {
+  return comments
+    .filter(comment => comment.type === 'Line')
+    .find(isChunkNameComment);
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Requires that all dynamic imports contain a `webpackChunkName` comment.',
+      category: 'Best Practices',
+      recommended: true,
+    },
+  },
+
+  create(context) {
+    const source = context.getSourceCode();
+    return {
+      CallExpression(node) {
+        if (!isDynamicImport(node)) {
+          return;
+        }
+
+        const comments = source.getComments(node.arguments[0]).leading;
+        const chunkNameBlockComment = comments
+          .filter(comment => comment.type === 'Block')
+          .find(isChunkNameComment);
+
+        if (!chunkNameBlockComment) {
+          context.report({
+            node,
+            message: hasLineChunkNameComment(comments)
+              ? 'webpackChunkName must be in a /* */ block comment'
+              : 'imports should have a webpackChunkName (https://webpack.js.org/api/module-methods/#import-)',
+          });
+        }
+      },
+    };
+  },
+};

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "mocha": "^3.4.2",
     "prettier": "^1.8.2",
     "react": "^15.6.1",
-    "react-dom": "^15.6.1"
+    "react-dom": "^15.6.1",
+    "typescript": "^2.6.2"
   },
   "peerDependencies": {
     "eslint": "<5 >=4.7.1"

--- a/tests/lib/rules/webpack/no-unnamed-dynamic-imports.js
+++ b/tests/lib/rules/webpack/no-unnamed-dynamic-imports.js
@@ -1,0 +1,91 @@
+const {RuleTester} = require('eslint');
+const rule = require('../../../../lib/rules/webpack/no-unnamed-dynamic-imports');
+
+const ruleTester = new RuleTester();
+
+const CHUNK_NAME_REQUIRED =
+  'imports should have a webpackChunkName (https://webpack.js.org/api/module-methods/#import-)';
+
+const validExamples = [
+  {
+    code: `
+      function foo() {
+        return import(/* webpackChunkName: "bar" */ 'bar');
+      }
+    `,
+    parser: 'babel-eslint',
+  },
+  {
+    code: `
+      function foo() {
+        return import(/* webpackChunkName: 'bar' */ 'bar');
+      }
+    `,
+    parser: 'babel-eslint',
+  },
+  {
+    code: `
+      async function foo() {
+        await import(/* webpackChunkName: 'bar' */ 'bar');
+      }
+    `,
+    parser: 'babel-eslint',
+  },
+  {
+    code: `System.import(/* webpackChunkName: "bar" */ 'bar');`,
+  },
+  {
+    code: `
+      System.import(
+        /* webpackMode: "lazy" */
+        /* webpackChunkName: "bar" */ 'bar'
+      );
+    `,
+  },
+  {
+    code: `System.imported('foo');`,
+  },
+  {
+    code: `System.other('foo');`,
+  },
+  {
+    code: `
+    async function foo() {
+      return System.import<{default: any}>(
+        /* webpackChunkName: "bar" */ './bar',
+      ).then(bar => bar);
+    }
+    `,
+    parser: 'typescript-eslint-parser',
+  },
+];
+
+const invalidExamples = [
+  {
+    code: `function foo() { import('bar'); }`,
+    options: ['never'],
+    parser: 'babel-eslint',
+    errors: [CHUNK_NAME_REQUIRED],
+  },
+  {
+    code: `function foo() { System.import('bar'); }`,
+    options: ['never'],
+    errors: [CHUNK_NAME_REQUIRED],
+  },
+  {
+    code: `
+      System.import(
+        // webpackChunkName: "bar"
+        'bar'
+      );
+    `,
+    options: ['never'],
+    parser: 'babel-eslint',
+    errors: ['webpackChunkName must be in a /* */ block comment'],
+  },
+];
+
+ruleTester.run('webpack/no-unnamed-dynamic-imports', rule, {
+  valid: validExamples,
+  invalid: invalidExamples,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3458,6 +3458,10 @@ typescript-eslint-parser@^9.0.0:
     lodash.unescape "4.0.1"
     semver "5.4.1"
 
+typescript@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
+
 ua-parser-js@^0.7.9:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"


### PR DESCRIPTION
### What?
This rule mandates a [`webpackChunkName` block comment](https://webpack.js.org/api/module-methods/#import-) for all `import` and `System.import` calls.  

### Why?
Omiting a dynamic import's `webpackChunkName` leads to hashed JavaScript filenames being deployed to production servers.  Including a human-readable fragment in filenames makes stack traces more readable, and improves triage accuracy.
