### PR TITLE
Fix `rules-status` / `rules-omitted` scripts

### DIFF
--- a/lib/config/all.js
+++ b/lib/config/all.js
@@ -35,9 +35,6 @@ module.exports = {
     'shopify',
     'sort-class-members',
     'typescript',
-    'typescript-prettier',
-    'typescript-react',
-    'webpack',
   ],
 
   rules: merge(
@@ -59,13 +56,11 @@ module.exports = {
     require('./rules/jsx-a11y'),
     require('./rules/lodash'),
     require('./rules/node'),
-    require('./rules/prettier'),
     require('./rules/promise'),
     require('./rules/react'),
     require('./rules/shopify'),
     require('./rules/sort-class-members'),
     require('./rules/typescript'),
-    require('./rules/typescript-prettier'),
     require('./rules/typescript-react'),
     require('./rules/webpack')
   ),

--- a/lib/config/rules/webpack.js
+++ b/lib/config/rules/webpack.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // Requires that all dynamic imports contain a `webpackChunkName` comment.
+  'shopify/webpack/no-unnamed-dynamic-imports': 'error',
+};

--- a/lib/config/webpack.js
+++ b/lib/config/webpack.js
@@ -1,6 +1,5 @@
+const merge = require('merge');
+
 module.exports = {
-  rules: {
-    // Requires that all dynamic imports contain a `webpackChunkName` comment.
-    'shopify/webpack/no-unnamed-dynamic-imports': 'error',
-  },
+  rules: merge(require('./rules/webpack')),
 };

--- a/tests/lib/config/all.js
+++ b/tests/lib/config/all.js
@@ -1,0 +1,16 @@
+/* eslint-env node, mocha */
+/* eslint-disable flowtype/require-valid-file-annotation */
+import {execSync} from 'child_process';
+
+const path = require('path');
+
+describe('config', () => {
+  describe('all', () => {
+    it('has valid plugins and requires', () => {
+      const allConfigPath = path.join(process.cwd(), 'lib', 'config', 'all.js');
+      execSync(
+        `node_modules/.bin/eslint --config ${allConfigPath} ${__dirname}`,
+      );
+    });
+  });
+});


### PR DESCRIPTION
Some problems:
- `all` was trying to include non-existent plugins 😬
- `all` was trying to require non-existent rule files

🎩 
* `yarn run rules-status` should produce a nicely formatted table
* `yarn run rules-omitted` should produce a nice list of rule names
