### PR TITLE
[DO NOT MERGE] Update typescript-eslint-parser for TypeScript 2.7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,6 @@
     "eslint-plugin-typescript": "^0.8.1",
     "merge": "^1.2.0",
     "pkg-dir": "^2.0.0",
-    "typescript-eslint-parser": "^11.0.0"
+    "typescript-eslint-parser": "^13.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1504,7 +1504,7 @@ eslint-plugin-react@^7.5.1:
     prop-types "^15.6.0"
 
 "eslint-plugin-shopify@file:./.":
-  version "18.3.1"
+  version "19.0.0"
   dependencies:
     babel-eslint "^8.2.1"
     eslint-config-prettier "^2.9.0"
@@ -3169,6 +3169,10 @@ semver@5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
+semver@5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -3448,6 +3452,13 @@ typescript-eslint-parser@^11.0.0:
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.4.1"
+
+typescript-eslint-parser@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-13.0.0.tgz#57f9be603d0fad7c26da76c2be67c0779d23362c"
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 typescript@^2.6.2:
   version "2.6.2"


### PR DESCRIPTION
`typescript-eslint-parser` will fail on projects upgrading to Typescript 2.7. 
<img width="885" alt="screen shot 2018-02-11 at 12 07 55 am" src="https://user-images.githubusercontent.com/6130700/36069952-befd47e4-0ebf-11e8-8329-d01d920f1267.png">

Merging this PR will address those concerns but introduce new ones. Old projects on 2.6.x will see the inverse of the screenshot above. If we don't want to enforce TypeScript 2.7.x, we can close this PR. 

For projects wanting to use TS 2.7, an acceptable workaround imo is to update `typescript-eslint-parser` to the latest in their respective projects `package.json` and run `yarn install`: 
```
  "resolutions": {
    "typescript-eslint-parser": "13.0.0"
  }
```