### PR TITLE
Fix empty string children breaking hardcoded content rule

### DIFF
--- a/lib/rules/jsx-no-hardcoded-content.js
+++ b/lib/rules/jsx-no-hardcoded-content.js
@@ -88,16 +88,14 @@ module.exports = {
         if (check.prop === 'children') {
           context.report(
             node,
-            `Do not use hardcoded content as the children of the ${
-              elementName
-            } component.`,
+            `Do not use hardcoded content as the children of the ${elementName} component.`,
           );
         } else if (check.prop) {
           context.report(
             node,
-            `Do not use hardcoded content in the ${check.prop} prop of the ${
-              elementName
-            } component.`,
+            `Do not use hardcoded content in the ${
+              check.prop
+            } prop of the ${elementName} component.`,
           );
         }
       },
@@ -164,7 +162,7 @@ function checkContent(
   function isInvalidProp(propNode) {
     return (
       propNode.type === 'JSXAttribute' &&
-      checkProps.some(prop => prop === propNode.name.name) &&
+      checkProps.some((prop) => prop === propNode.name.name) &&
       isInvalidContent(
         propNode.value == null
           ? {type: 'Literal', value: true}

--- a/lib/rules/jsx-no-hardcoded-content.js
+++ b/lib/rules/jsx-no-hardcoded-content.js
@@ -88,14 +88,16 @@ module.exports = {
         if (check.prop === 'children') {
           context.report(
             node,
-            `Do not use hardcoded content as the children of the ${elementName} component.`,
+            `Do not use hardcoded content as the children of the ${
+              elementName
+            } component.`,
           );
         } else if (check.prop) {
           context.report(
             node,
-            `Do not use hardcoded content in the ${
-              check.prop
-            } prop of the ${elementName} component.`,
+            `Do not use hardcoded content in the ${check.prop} prop of the ${
+              elementName
+            } component.`,
           );
         }
       },
@@ -138,6 +140,10 @@ function getImportDetailsForJSX({openingElement}, context) {
   };
 }
 
+function isEmptyString(string) {
+  return string.trim().length === 0;
+}
+
 function checkContent(
   node,
   {allowStrings = false, allowNumbers = true, checkProps = []},
@@ -145,7 +151,9 @@ function checkContent(
   function isInvalidContent(contentNode) {
     return (
       (contentNode.type === 'Literal' &&
-        ((!allowStrings && typeof contentNode.value === 'string') ||
+        ((!allowStrings &&
+          typeof contentNode.value === 'string' &&
+          !isEmptyString(contentNode.value)) ||
           (!allowNumbers && typeof contentNode.value === 'number'))) ||
       (contentNode.type === 'TemplateLiteral' && !allowStrings) ||
       (contentNode.type === 'JSXExpressionContainer' &&
@@ -156,7 +164,7 @@ function checkContent(
   function isInvalidProp(propNode) {
     return (
       propNode.type === 'JSXAttribute' &&
-      checkProps.some((prop) => prop === propNode.name.name) &&
+      checkProps.some(prop => prop === propNode.name.name) &&
       isInvalidContent(
         propNode.value == null
           ? {type: 'Literal', value: true}

--- a/tests/lib/rules/jsx-no-hardcoded-content.js
+++ b/tests/lib/rules/jsx-no-hardcoded-content.js
@@ -11,12 +11,8 @@ const parser = 'babel-eslint';
 function errorsFor(component, prop) {
   const message =
     prop === 'children'
-      ? `Do not use hardcoded content as the children of the ${
-          component
-        } component.`
-      : `Do not use hardcoded content in the ${prop} prop of the ${
-          component
-        } component.`;
+      ? `Do not use hardcoded content as the children of the ${component} component.`
+      : `Do not use hardcoded content in the ${prop} prop of the ${component} component.`;
 
   return [{type: 'JSXElement', message}];
 }

--- a/tests/lib/rules/jsx-no-hardcoded-content.js
+++ b/tests/lib/rules/jsx-no-hardcoded-content.js
@@ -11,8 +11,12 @@ const parser = 'babel-eslint';
 function errorsFor(component, prop) {
   const message =
     prop === 'children'
-      ? `Do not use hardcoded content as the children of the ${component} component.`
-      : `Do not use hardcoded content in the ${prop} prop of the ${component} component.`;
+      ? `Do not use hardcoded content as the children of the ${
+          component
+        } component.`
+      : `Do not use hardcoded content in the ${prop} prop of the ${
+          component
+        } component.`;
 
   return [{type: 'JSXElement', message}];
 }
@@ -24,7 +28,19 @@ const checkProps = {checkProps: ['foo']};
 ruleTester.run('jsx-no-hardcoded-content', rule, {
   valid: [
     {code: '<div />', parser},
+    {
+      code: `<div>
+        <div />
+      </div>`,
+      parser,
+    },
     {code: '<MyComponent />', parser},
+    {
+      code: `<MyComponent>
+        <div />
+      </MyComponent>`,
+      parser,
+    },
     {code: '<MyComponent>{true}</MyComponent>', parser},
     {code: '<MyComponent>{2}</MyComponent>', parser},
     {code: '<MyComponent>{true}</MyComponent>', parser},


### PR DESCRIPTION
Fixes https://github.com/Shopify/eslint-plugin-shopify/issues/81. TIL that the spacing in JSX elements actually creates extra literals — the newline in something like

```
<div>
  <div />
</div>
```

Was adding extra string literals that were violating this rule. To fix, I just make sure we have a non-zero length string, which technically means this would now pass: `<div>{""}</div>`. Seems like a worthwhile sacrifice (it would be annoying to have to pass down the context to still catch this case).