### PR TITLE
Turn off unnecessary/ bad rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Removed
+* **Breaking:** turned off four rules that previously triggered errors in all cases:
+  * `shopify/react-type-state` (TypeScript now addresses the issue this rule was meant to catch)
+  * `promise/always-return`
+  * `react/no-did-mount-set-state`
+  * `no-undefined`
+* **Breaking:** turned off two rules in specific plugins:
+  * `babel/no-invalid-this` (turned off for the `typescript` configs as TypeScript has better mechanisms for unsuring a valid `this` is used)
+  * `no-process-env` (turned off for the `webpack` and `node` configs as both targets can benefit from use of `process.env`)
 
 ## [20.0.0] - 2018-03-15
 * **Breaking:** the version of TypeScript supported by this plugin is 2.7.x (in line with [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser)’s TypeScript support)

--- a/lib/config/node.js
+++ b/lib/config/node.js
@@ -1,3 +1,5 @@
+const merge = require('merge');
+
 module.exports = {
   env: {
     node: true,
@@ -5,5 +7,7 @@ module.exports = {
 
   plugins: ['node'],
 
-  rules: require('./rules/node'),
+  rules: merge(require('./rules/node'), {
+    'no-process-env': 'off',
+  }),
 };

--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -21,7 +21,6 @@ module.exports = {
 
   rules: merge(require('./rules/react'), require('./rules/jsx-a11y'), {
     'shopify/react-initialize-state': 'error',
-    'shopify/react-type-state': 'error',
     'shopify/jsx-no-complex-expressions': 'error',
   }),
 };

--- a/lib/config/rules/promise.js
+++ b/lib/config/rules/promise.js
@@ -9,7 +9,7 @@ module.exports = {
   // Avoid wrapping values in Promise.resolve or Promise.reject when not needed
   'promise/no-return-wrap': 'error',
   // Ensure that inside a then() you make sure to return a new promise or value.
-  'promise/always-return': 'error',
+  'promise/always-return': 'off',
   // Enforce standard parameter names for Promise constructors.
   'promise/param-names': 'error',
   // Ensure that Promise is included fresh in each file instead of relying on the existence of a native promise implementation.

--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -34,9 +34,9 @@ module.exports = {
   // Prevent usage of deprecated methods
   'react/no-deprecated': 'error',
   // Prevent usage of setState in componentDidMount
-  'react/no-did-mount-set-state': 'error',
+  'react/no-did-mount-set-state': 'off',
   // Prevent usage of setState in componentDidUpdate
-  'react/no-did-update-set-state': 'error',
+  'react/no-did-update-set-state': 'off',
   // Prevent direct mutation of this.state
   'react/no-direct-mutation-state': 'error',
   // Prevent usage of findDOMNode

--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -36,7 +36,7 @@ module.exports = {
   // Prevent usage of setState in componentDidMount
   'react/no-did-mount-set-state': 'off',
   // Prevent usage of setState in componentDidUpdate
-  'react/no-did-update-set-state': 'off',
+  'react/no-did-update-set-state': 'error',
   // Prevent direct mutation of this.state
   'react/no-direct-mutation-state': 'error',
   // Prevent usage of findDOMNode

--- a/lib/config/rules/variables.js
+++ b/lib/config/rules/variables.js
@@ -20,7 +20,7 @@ module.exports = {
   // Disallow use of undeclared variables unless mentioned in a /*global */ block
   'no-undef': 'error',
   // Disallow use of undefined variable
-  'no-undefined': 'error',
+  'no-undefined': 'off',
   // Disallow declaration of variables that are not used in the code
   'no-unused-vars': 'error',
   // Disallow use of variables before they are defined

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -12,5 +12,10 @@ module.exports = {
     sourceType: 'module',
   },
 
-  rules: merge(require('./rules/typescript')),
+  rules: merge(require('./rules/typescript'), {
+    // TypeScript provides a better mechanism (explicit `this` type)
+    // for ensuring proper `this` usage in functions not assigned to
+    // object properties.
+    'babel/no-invalid-this': 'off',
+  }),
 };

--- a/lib/config/webpack.js
+++ b/lib/config/webpack.js
@@ -1,5 +1,7 @@
 const merge = require('merge');
 
 module.exports = {
-  rules: merge(require('./rules/webpack')),
+  rules: merge(require('./rules/webpack'), {
+    'no-process-env': 'off',
+  }),
 };


### PR DESCRIPTION
As we are slowly [turning on all ESLint rules in web](https://github.com/Shopify/web/issues/2073), a few have stuck out as being bad/ unnecessary. This PR turns them off, and I have commented on why I feel they should be turned off inline.