### PR TITLE
Adds option to check DOM/ Web Component props for hardcoded content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+* `shopify/jsx-no-hardcoded-content` now accepts a `dom` option that allows specifying attributes on DOM elements and Web Components to be checked for hardcoded content.
+
 ### Removed
 * **Breaking:** turned off four rules that previously triggered errors in all cases:
   * `shopify/react-type-state` (TypeScript now addresses the issue this rule was meant to catch)

--- a/docs/rules/jsx-no-hardcoded-content.md
+++ b/docs/rules/jsx-no-hardcoded-content.md
@@ -63,6 +63,49 @@ The following patterns are not warnings:
 <MyComponent bar="baz" />
 ```
 
+### `dom`
+
+Allows you to specify custom validation logic for DOM elements and Web Components. This options should be an object where:
+
+* The key is the name of the DOM element or Web Component, or the string `'*'` to indicate all elements
+* The value is an object which has `allowStrings`, `allowNumbers`, and/ or `checkProps`, as detailed above.
+
+By default, the following properties are checked on DOM elements (in addition to children):
+
+```js
+{
+  '*': {checkProps: ['title', 'aria-label']},
+  area: {checkProps: ['title', 'alt', 'aria-label']},
+  img: {checkProps: ['title', 'alt', 'aria-label']},
+  input: {checkProps: ['title', 'alt', 'placeholder', 'aria-label']},
+}
+```
+
+Note that overriding any of these completely replaces the default, so you must specify all props you wish to check, not just your additional set. Note, too, that the options specified for `'*'` are not merged in with more specific element options, so the specific element options will win when there are conflicts.
+
+With:
+
+```js
+{
+  dom: {
+    'my-custom-element': {checkProps: ['foo']},
+  },
+}
+```
+
+The following patterns are considered warnings:
+
+```js
+<my-custom-element foo="Content" />
+```
+
+The following are not warnings:
+
+```js
+<my-custom-element foo={variableContent} />
+<other-custom-element foo="Content" />
+```
+
 ### `modules`
 
 Allows you to specify custom validation logic for components in different modules. This option should be an object where:
@@ -90,7 +133,7 @@ With:
 }
 ```
 
-the following patterns are considered warnings:
+The following patterns are considered warnings:
 
 ```js
 import {OtherComponent, MyComponent} from 'my-module';

--- a/lib/rules/jsx-no-hardcoded-content.js
+++ b/lib/rules/jsx-no-hardcoded-content.js
@@ -4,6 +4,13 @@ const {
   NAMESPACE_IMPORT,
 } = require('../utilities');
 
+const defaultDOMOptions = {
+  '*': {checkProps: ['title', 'aria-label']},
+  area: {checkProps: ['title', 'alt', 'aria-label']},
+  img: {checkProps: ['title', 'alt', 'aria-label']},
+  input: {checkProps: ['title', 'alt', 'placeholder', 'aria-label']},
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -26,6 +33,26 @@ module.exports = {
           checkProps: {
             type: 'array',
             items: {type: 'string'},
+          },
+          dom: {
+            type: 'object',
+            additionalProperties: {
+              type: 'object',
+              properties: {
+                allowNumbers: {
+                  type: 'boolean',
+                },
+                allowStrings: {
+                  type: 'boolean',
+                },
+                checkProps: {
+                  items: {
+                    type: 'string',
+                  },
+                  type: 'array',
+                },
+              },
+            },
           },
           modules: {
             type: 'object',
@@ -59,8 +86,26 @@ module.exports = {
   create(context) {
     const defaultOptions = context.options[0] || {};
     const modules = defaultOptions.modules || {};
+    const dom = defaultOptions.dom || {};
+    const optionsForAllDOM = dom['*'] || defaultDOMOptions['*'];
+
+    const defaultOptionsForUnspecifiedDOMElement = Object.assign(
+      {},
+      defaultOptions,
+      optionsForAllDOM,
+    );
 
     function optionsForNode(node) {
+      if (isDOMElement(node)) {
+        const {name} = node.openingElement.name;
+
+        return (
+          dom[node.openingElement.name.name] ||
+          defaultDOMOptions[name] ||
+          defaultOptionsForUnspecifiedDOMElement
+        );
+      }
+
       const importDetails = getImportDetailsForJSX(node, context);
 
       if (importDetails == null) {
@@ -142,6 +187,10 @@ function getImportDetailsForJSX({openingElement}, context) {
 
 function isEmptyString(string) {
   return string.trim().length === 0;
+}
+
+function isDOMElement({openingElement: {name}}) {
+  return name.type === 'JSXIdentifier' && name.name === name.name.toLowerCase();
 }
 
 function checkContent(

--- a/tests/lib/rules/jsx-no-hardcoded-content.js
+++ b/tests/lib/rules/jsx-no-hardcoded-content.js
@@ -24,6 +24,10 @@ const checkProps = {checkProps: ['foo']};
 ruleTester.run('jsx-no-hardcoded-content', rule, {
   valid: [
     {code: '<div />', parser},
+    {code: '<div aria-label={someVariable} />', parser},
+    {code: '<div title={someVariable} />', parser},
+    {code: '<img alt={someVariable} />', parser},
+    {code: '<input placeholder={someVariable} />', parser},
     {
       code: `<div>
         <div />
@@ -392,6 +396,40 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
     },
   ],
   invalid: [
+    {
+      code: '<div aria-label="Content" />',
+      parser,
+      errors: errorsFor('div', 'aria-label'),
+    },
+    {
+      code: '<div title="Content" />',
+      parser,
+      errors: errorsFor('div', 'title'),
+    },
+    {
+      code: '<img alt="Content" />',
+      parser,
+      errors: errorsFor('img', 'alt'),
+    },
+    {
+      code: '<input placeholder="Content" />',
+      parser,
+      errors: errorsFor('input', 'placeholder'),
+    },
+    {
+      code: '<my-element placeholder="Content" />',
+      parser,
+      errors: errorsFor('my-element', 'placeholder'),
+      options: [
+        {
+          dom: {
+            'my-element': {
+              checkProps: ['placeholder'],
+            },
+          },
+        },
+      ],
+    },
     {
       code: '<MyComponent>Content</MyComponent>',
       parser,


### PR DESCRIPTION
This PR adds a new option, `dom`, to the `jsx-no-hardcoded-content` rule. It allows the specification of custom validation logic for DOM elements and Web Components, and provides a few sensible defaults.