### PR TITLE
Add `no-vague-titles` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 ### Added
-* `shopify/jsx-prefer-fragment-wrappers` ([#95](https://github.com/Shopify/eslint-plugin-shopify/pull/94))
+* `shopify/jsx-prefer-fragment-wrappers` ([#94](https://github.com/Shopify/eslint-plugin-shopify/pull/94))
+* `shopify/jest/no-vague-titles` ([#93](https://github.com/Shopify/eslint-plugin-shopify/pull/93))
 
 ## [22.1.0] - 2018-06-08
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ This plugin provides the following custom rules, which are included as appropria
 
 - [binary-assignment-parens](docs/rules/binary-assignment-parens.md): Require (or disallow) assignments of binary, boolean-producing expressions to be wrapped in parentheses.
 - [class-property-semi](docs/rules/class-property-semi.md): Require (or disallow) semicolons for class properties.
+- [jest/no-vague-titles](docs/rules/jest/no-vague-titles.md): Prevent the usage of vague words in test statements.
 - [jquery-dollar-sign-reference](docs/rules/jquery-dollar-sign-reference.md): Require that all jQuery objects are assigned to references prefixed with `$`.
 - [jsx-no-complex-expressions](docs/rules/jsx-no-complex-expressions.md): Disallow complex expressions embedded in in JSX.
 - [jsx-no-hardcoded-content](docs/rules/jsx-no-hardcoded-content.md): Disallow hardcoded content in JSX.

--- a/docs/rules/jest/no-vague-titles.md
+++ b/docs/rules/jest/no-vague-titles.md
@@ -1,0 +1,53 @@
+# Prevent the usage of vague words in test statements. (no-vague-titles)
+This rule encourages more explicit test descriptions by preventing the use of the vague words, such as "correct" and "appropriate".
+
+## Rule Details
+
+Using vague words in test descriptions often fail to communicate the meaningful details of what the underlying code is meant to do. Enabling this rule will encourage developers to write more specific and readable test descriptions.
+
+Examples of **incorrect** code for this rule:
+
+```js
+it('is called with the correct parameters')
+test('renders the appropriate markup')
+describe('receives the correct props')
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+it(`is called with the user's id and password`)
+test('renders the user avatar and email')
+describe('receives the date and publishState props from the router params')
+```
+
+### `ignore`
+
+```json
+{
+  "jest/no-vague-titles": [
+    "error",
+    {
+      "ignore": ["describe", "test"]
+    }
+  ]
+}
+```
+
+This array option whitelists function names so that this rule does not report their usage as being incorrect. There are eight possible values.
+
+* `"describe"`
+* `"test"`
+* `"it"`
+* `"xdescribe"`
+* `"xtest"`
+* `"xit"`
+* `"fdescribe"`
+* `"fit"`
+
+By default, none of these options are enabled (the equivalent of `{ "ignore": [] }`).
+
+## When Not To Use It
+
+If you do not wish to prevent the use of the vague words in test descriptions, you can safely disable this rule.

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ module.exports = {
   rules: {
     'binary-assignment-parens': require('./lib/rules/binary-assignment-parens'),
     'class-property-semi': require('./lib/rules/class-property-semi'),
+    'jest/no-vague-titles': require('./lib/rules/jest/no-vague-titles'),
     'jquery-dollar-sign-reference': require('./lib/rules/jquery-dollar-sign-reference'),
     'jsx-no-complex-expressions': require('./lib/rules/jsx-no-complex-expressions'),
     'jsx-no-hardcoded-content': require('./lib/rules/jsx-no-hardcoded-content'),

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -1,0 +1,96 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prevent the usage of vague words in test statements.',
+      category: 'Best Practices',
+      recommended: false,
+      uri:
+        'https://github.com/Shopify/eslint-plugin-shopify/blob/master/docs/rules/no-vague-titles.md',
+    },
+  },
+  create(context) {
+    const ignored = (context.options[0] && context.options[0].ignore) || [];
+
+    function isIgnoredFunctionName({callee}) {
+      return ignored.some(
+        (method) =>
+          callee.name ? method === callee.name : method === callee.object.name,
+      );
+    }
+
+    function validate(node) {
+      if (
+        notTestFunction(node) ||
+        isIgnoredFunctionName(node) ||
+        hasEmptyDescription(node)
+      ) {
+        return;
+      }
+
+      const description = getDescription(node);
+
+      if (containsVagueWord(description)) {
+        context.report({
+          message: `{{ method }} description should not contain vague words. Be sure the description meaningfully illustrates the purpose of this test.`,
+          data: {
+            method: node.callee.name
+              ? node.callee.name
+              : node.callee.object.name,
+          },
+          node,
+        });
+      }
+    }
+
+    return {
+      CallExpression(node) {
+        validate(node);
+      },
+    };
+  },
+};
+
+function notTestFunction({callee}) {
+  return callee.name
+    ? !matchTestFunctionName(callee.name)
+    : !matchTestFunctionName(callee.object.name);
+}
+
+function matchTestFunctionName(functionName) {
+  return (
+    functionName === 'it' ||
+    functionName === 'xit' ||
+    functionName === 'fit' ||
+    functionName === 'test' ||
+    functionName === 'xtest' ||
+    functionName === 'describe' ||
+    functionName === 'fdescribe' ||
+    functionName === 'xdescribe'
+  );
+}
+
+function hasEmptyDescription({arguments: args}) {
+  return (
+    !args ||
+    !args[0] ||
+    (args[0].type !== 'Literal' && args[0].type !== 'TemplateLiteral')
+  );
+}
+
+function getDescription({arguments: args}) {
+  const firstArgument = args[0];
+
+  if (firstArgument.type === 'TemplateLiteral') {
+    return firstArgument.quasis
+      .map((templateLiteral) => {
+        return templateLiteral.value.raw;
+      })
+      .join('');
+  }
+
+  return firstArgument && firstArgument.value;
+}
+
+function containsVagueWord(description) {
+  return description.match(/correct/i) || description.match(/appropriate/i);
+}

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -1,0 +1,602 @@
+const {RuleTester} = require('eslint');
+const rule = require('../../../../lib/rules/jest/no-vague-titles');
+
+const ruleTester = new RuleTester();
+
+require('babel-eslint');
+
+const parser = 'babel-eslint';
+
+function errorWithMethod(method) {
+  return [
+    {
+      type: 'CallExpression',
+      message: `${method} description should not contain vague words. Be sure the description meaningfully illustrates the purpose of this test.`,
+    },
+  ];
+}
+ruleTester.run('no-vague-titles', rule, {
+  valid: [
+    {
+      code: `it()`,
+      parser,
+    },
+    {
+      code: `it('')`,
+      parser,
+    },
+    {
+      code: `it('foo bar baz')`,
+      parser,
+    },
+    {
+      code: `xit('foo bar baz')`,
+      parser,
+    },
+    {
+      code: `it.only('foo bar baz')`,
+      parser,
+    },
+    {
+      code: `describe('foo bar baz')`,
+      parser,
+    },
+    {
+      code: `xdescribe('foo bar baz')`,
+      parser,
+    },
+    {
+      code: `describe.only('foo bar baz')`,
+      parser,
+    },
+    {
+      code: `test('foo bar baz')`,
+      parser,
+    },
+    {
+      code: `xtest('foo bar baz')`,
+      parser,
+    },
+    {
+      code: `test.only('foo bar baz')`,
+      parser,
+    },
+    {
+      code: `someFunction('correct')`,
+      parser,
+    },
+    {
+      code: `someFunction('incorrect')`,
+      parser,
+    },
+    {
+      code: `someFunction('correctly')`,
+      parser,
+    },
+    {
+      code: `someFunction('incorrectly')`,
+      parser,
+    },
+    {
+      code: `someFunction('Correct')`,
+      parser,
+    },
+    {
+      code: `someFunction('appropriate')`,
+      parser,
+    },
+    {
+      code: `someFunction('inappropriate')`,
+      parser,
+    },
+    {
+      code: `someFunction('Appropriate')`,
+      parser,
+    },
+    {
+      code: `someFunction('appropriately')`,
+      parser,
+    },
+    {
+      code: `someFunction.only('correct')`,
+      parser,
+    },
+  ],
+  invalid: [
+    {
+      code: "it('correct')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it('correctly')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it('incorrect')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it('Correct')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('correct')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('correctly')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('incorrect')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('Correct')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "xit('correct')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "xit('correctly')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "xit('incorrect')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "xit('Correct')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "describe('correct')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe('correct')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe('correctly')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe('incorrect')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe('Correct')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "xdescribe('correct')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "xdescribe('correct')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "xdescribe('correctly')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "xdescribe('incorrect')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "xdescribe('Correct')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "describe.only('correct')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe.only('correctly')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe.only('incorrect')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe.only('Correct')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "test('correct')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test('correct')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test('correctly')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test('incorrect')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test('Correct')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "xtest('correct')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "xtest('correct')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "xtest('correctly')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "xtest('incorrect')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "xtest('Correct')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "test.only('correct')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test.only('correctly')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test.only('incorrect')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test.only('Correct')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "it('appropriate')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it('appropriately')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it('inappropriate')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it('Appropriate')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "xit('appropriate')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "xit('appropriately')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "xit('inappropriate')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "xit('Appropriate')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "fit('appropriate')",
+      parser,
+      errors: errorWithMethod('fit'),
+    },
+    {
+      code: "fit('appropriate')",
+      parser,
+      errors: errorWithMethod('fit'),
+    },
+    {
+      code: "fit('appropriately')",
+      parser,
+      errors: errorWithMethod('fit'),
+    },
+    {
+      code: "fit('inappropriate')",
+      parser,
+      errors: errorWithMethod('fit'),
+    },
+    {
+      code: "fit('Appropriate')",
+      parser,
+      errors: errorWithMethod('fit'),
+    },
+    {
+      code: "describe('appropriate')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe('appropriate')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe('appropriately')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe('inappropriate')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "describe('Appropriate')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "xdescribe('appropriate')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "xdescribe('appropriate')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "xdescribe('appropriately')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "xdescribe('inappropriate')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "xdescribe('Appropriate')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "test('appropriate')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test('appropriate')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test('appropriately')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test('inappropriate')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test('Appropriate')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "xtest('appropriate')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "xtest('appropriate')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "xtest('appropriately')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "xtest('inappropriate')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "xtest('Appropriate')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+  ],
+});
+
+ruleTester.run('no-tests-contain-correct with ignore=describe', rule, {
+  valid: [
+    {
+      code: "describe('correct')",
+      options: [{ignore: ['describe']}],
+    },
+    {
+      code: "describe('correctly')",
+      options: [{ignore: ['describe']}],
+    },
+    {
+      code: 'describe("Correct")',
+      options: [{ignore: ['describe']}],
+    },
+    {
+      code: 'describe("incorrect")',
+      options: [{ignore: ['describe']}],
+    },
+    {
+      code: "describe('appropriate')",
+      options: [{ignore: ['describe']}],
+    },
+    {
+      code: "describe('appropriately')",
+      options: [{ignore: ['describe']}],
+    },
+    {
+      code: 'describe("Appropriate")',
+      options: [{ignore: ['describe']}],
+    },
+    {
+      code: 'describe("inappropriate")',
+      options: [{ignore: ['describe']}],
+    },
+    {
+      code: "describe('appropriate')",
+      options: [{ignore: ['describe']}],
+    },
+    {
+      code: "describe.only('appropriate')",
+      options: [{ignore: ['describe']}],
+    },
+  ],
+  invalid: [],
+});
+
+ruleTester.run('no-tests-contain-correct with ignore=test', rule, {
+  valid: [
+    {
+      code: "test('correct')",
+      options: [{ignore: ['test']}],
+    },
+    {
+      code: "test('correctly')",
+      options: [{ignore: ['test']}],
+    },
+    {
+      code: 'test("Correct")',
+      options: [{ignore: ['test']}],
+    },
+    {
+      code: 'test("incorrect")',
+      options: [{ignore: ['test']}],
+    },
+    {
+      code: "test('appropriate')",
+      options: [{ignore: ['test']}],
+    },
+    {
+      code: "test('appropriately')",
+      options: [{ignore: ['test']}],
+    },
+    {
+      code: 'test("Appropriate")',
+      options: [{ignore: ['test']}],
+    },
+    {
+      code: 'test("inappropriate")',
+      options: [{ignore: ['test']}],
+    },
+    {
+      code: 'test.only("appropriate")',
+      options: [{ignore: ['test']}],
+    },
+  ],
+  invalid: [],
+});
+
+ruleTester.run('no-tests-contain-correct with ignore=it', rule, {
+  valid: [
+    {
+      code: "it('correct')",
+      options: [{ignore: ['it']}],
+    },
+    {
+      code: "it('correctly')",
+      options: [{ignore: ['it']}],
+    },
+    {
+      code: 'it("Correct")',
+      options: [{ignore: ['it']}],
+    },
+    {
+      code: 'it("incorrect")',
+      options: [{ignore: ['it']}],
+    },
+    {
+      code: "it('appropriate')",
+      options: [{ignore: ['it']}],
+    },
+    {
+      code: "it('appropriately')",
+      options: [{ignore: ['it']}],
+    },
+    {
+      code: 'it("Appropriate")',
+      options: [{ignore: ['it']}],
+    },
+    {
+      code: 'it("inappropriate")',
+      options: [{ignore: ['it']}],
+    },
+    {
+      code: 'it.only("appropriate")',
+      options: [{ignore: ['it']}],
+    },
+  ],
+  invalid: [],
+});


### PR DESCRIPTION
Addresses one of the points here https://github.com/Shopify/eslint-plugin-shopify/issues/77 by testing the `it`, `describe` and `test` statements against a simple regex that looks for the word "correct". Will fill in the docs once the general approach is approved.
