### PR TITLE
Add `jsx-prefer-fragment-wrappers` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Added
+* `shopify/jsx-prefer-fragment-wrappers` ([#95](https://github.com/Shopify/eslint-plugin-shopify/pull/94))
+
 ## [22.1.0] - 2018-06-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ This plugin provides the following custom rules, which are included as appropria
 - [jquery-dollar-sign-reference](docs/rules/jquery-dollar-sign-reference.md): Require that all jQuery objects are assigned to references prefixed with `$`.
 - [jsx-no-complex-expressions](docs/rules/jsx-no-complex-expressions.md): Disallow complex expressions embedded in in JSX.
 - [jsx-no-hardcoded-content](docs/rules/jsx-no-hardcoded-content.md): Disallow hardcoded content in JSX.
+- [jsx-prefer-fragment-wrappers)](docs/rules/jsx-no-hardcoded-content.md): Disallow useless wrapping elements in favour of fragment shorthand in JSX.
 - [no-useless-computed-properties](docs/rules/no-useless-computed-properties.md): Prevent the usage of unnecessary computed properties.
 - [polaris-no-bare-stack-item](docs/rules/polaris-no-bare-stack-item.md): Disallow the use of Polaris’s `Stack.Item` without any custom props.
 - [polaris-prefer-sectioned-prop](docs/rules/polaris-prefer-sectioned-prop.md): Prefer the use of the `sectioned` props in Polaris components instead of wrapping all contents in a `Section` component.

--- a/docs/rules/jsx-prefer-fragment-wrappers.md
+++ b/docs/rules/jsx-prefer-fragment-wrappers.md
@@ -1,0 +1,39 @@
+# Disallow useless wrapping elements in favour of fragment shorthand in JSX. (jsx-prefer-fragment-wrappers)
+
+It is common in React for a component to return multiple elements. React Fragments provide a way to wrap a list of child nodes without adding an extra div to the DOM.
+
+## Rule Details
+
+This rule prevents the use of additional wrapping elements and enforces the use of React Fragments instead.
+
+Examples of **incorrect** code for this rule:
+
+```js
+render() {
+  return (
+    <div>
+      <ChildA />
+      <ChildB />
+      <ChildC />
+    </div>
+  );
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+render() {
+  return (
+    <>
+      <ChildA />
+      <ChildB />
+      <ChildC />
+    </>
+  );
+}
+```
+
+## When Not To Use It
+
+If you do not wish to enforce the use of React Fragments, you can safely disable this rule.

--- a/lib/rules/jsx-prefer-fragment-wrappers.js
+++ b/lib/rules/jsx-prefer-fragment-wrappers.js
@@ -1,0 +1,57 @@
+const pascalCase = require('pascal-case');
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Disallow useless wrapping elements in favour of fragment shorthand in JSX',
+      category: 'Best Practices',
+      recommended: false,
+      uri:
+        'https://github.com/Shopify/eslint-plugin-shopify/blob/master/docs/rules/jsx-prefer-fragment-wrappers.md',
+    },
+  },
+
+  create(context) {
+    return {
+      JSXElement(node) {
+        if (
+          isComponentOrFragment(node) ||
+          hasOneOrNoChildren(node) ||
+          hasAttributes(node)
+        ) {
+          return;
+        }
+
+        const {name} = node.openingElement.name;
+
+        context.report({
+          node,
+          message: 'replace wrapping {{name}} with fragment shorthand',
+          data: {name},
+        });
+      },
+    };
+  },
+};
+
+function isPascalCase(string) {
+  return string === pascalCase(string);
+}
+
+function hasOneOrNoChildren({children}) {
+  const childNodes = children.filter((child) => child.type !== 'Literal');
+  return childNodes.length < 2;
+}
+
+function isComponentOrFragment({openingElement: {name}}) {
+  if (name.type === 'JSXMemberExpression') {
+    return isPascalCase(name.object.name) && isPascalCase(name.property.name);
+  }
+
+  return isPascalCase(name.name);
+}
+
+function hasAttributes({openingElement: {attributes}}) {
+  return attributes && attributes.length !== 0;
+}

--- a/tests/lib/rules/jsx-prefer-fragment-wrappers.js
+++ b/tests/lib/rules/jsx-prefer-fragment-wrappers.js
@@ -1,0 +1,54 @@
+const {RuleTester} = require('eslint');
+const rule = require('../../../lib/rules/jsx-prefer-fragment-wrappers');
+
+require('babel-eslint');
+
+const parser = 'babel-eslint';
+const ruleTester = new RuleTester();
+function errorWithTagName(tagName) {
+  return [
+    {
+      type: 'JSXElement',
+      message: `replace wrapping ${tagName} with fragment shorthand`,
+    },
+  ];
+}
+
+ruleTester.run('jsx-prefer-fragment-wrappers', rule, {
+  valid: [
+    {code: '<div className={className}>{foo}{bar}<Baz /></div>', parser},
+    {code: '<div><Bar /></div>', parser},
+    {code: '<Foo><Bar /><Baz /></Foo>', parser},
+    {code: '<Foo>{someFunction()}</Foo>', parser},
+    {code: '<Foo>Some content</Foo>', parser},
+    {
+      code: '<React.Fragment><Foo /><Bar /><Baz /></React.Fragment>',
+      parser,
+    },
+    {
+      code: '<><Foo /><Bar /><Baz /></>',
+      parser,
+    },
+    {
+      code: '<Foo.Bar><Foo /><Bar /><Baz /></Foo.Bar>',
+      parser,
+    },
+  ],
+  invalid: [
+    {
+      code: '<span>{things}{things}</span>',
+      parser,
+      errors: errorWithTagName('span'),
+    },
+    {
+      code: '<div>{things}{things}</div>',
+      parser,
+      errors: errorWithTagName('div'),
+    },
+    {
+      code: '<div><Foo /><Bar /><Baz><Foo /></Baz></div>',
+      parser,
+      errors: errorWithTagName('div'),
+    },
+  ],
+});


### PR DESCRIPTION
Addresses one of the points here #77 by testing JSX code for useless wrapping elements. Will fill in the docs once the general approach is approved.