### PR TITLE
Add `react-prefer-private-members` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * `shopify/prefer-pascal-case-enums` ([#96](https://github.com/Shopify/eslint-plugin-shopify/pull/96))
+* `shopify/react-prefer-private-members` ([#95](https://github.com/Shopify/eslint-plugin-shopify/pull/95))
 
 ## [22.0.0]
 * Updated dependencies

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ This plugin provides the following custom rules, which are included as appropria
 - [prefer-pascal-case-enums](docs/rules/prefer-pascal-case-enums.md): Prefer TypeScript enums be defined using pascal case.
 - [prefer-twine](docs/rules/prefer-twine.md): Prefer Twine over Bindings as the name for twine imports.
 - [react-initialize-state](docs/rules/react-initialize-state.md): Require that React component state be initialized when it has a non-empty type.
+- [react-prefer-private-members](docs/rules/react-prefer-private-members.md): Prefer all non-React-specific members be marked private in React class components.
 - [react-type-state](docs/rules/react-type-state.md): Require that React component state be typed in TypeScript.
 - [restrict-full-import](docs/rules/restrict-full-import.md): Prevent importing the entirety of a package.
 - [sinon-no-restricted-features](docs/rules/sinon-no-restricted-features.md): Restrict the use of specified sinon features.

--- a/docs/rules/react-prefer-private-members.md
+++ b/docs/rules/react-prefer-private-members.md
@@ -1,11 +1,10 @@
 # Disallow public members within React component classes (react-prefer-private-members)
 
-Please describe the origin of the rule here.
-
+This rule enforces all non-React-specific members be marked private in React class components.
 
 ## Rule Details
 
-This rule aims to...
+When a member of class is marked private, it cannot be accessed from outside of its containing class. This restriction is prefered when writing React components, where encapsulation is almost always desireable.
 
 Examples of **incorrect** code for this rule:
 
@@ -23,14 +22,6 @@ Examples of **correct** code for this rule:
 
 ```
 
-### Options
-
-If there are any options, describe them here. Otherwise, delete this section.
-
 ## When Not To Use It
 
 Give a short description of when it would be appropriate to turn off this rule.
-
-## Further Reading
-
-If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/docs/rules/react-prefer-private-members.md
+++ b/docs/rules/react-prefer-private-members.md
@@ -1,0 +1,36 @@
+# Disallow public members within React component classes (react-prefer-private-members)
+
+Please describe the origin of the rule here.
+
+
+## Rule Details
+
+This rule aims to...
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+// fill me in
+
+```
+
+### Options
+
+If there are any options, describe them here. Otherwise, delete this section.
+
+## When Not To Use It
+
+Give a short description of when it would be appropriate to turn off this rule.
+
+## Further Reading
+
+If there are other links that describe the issue this rule addresses, please include them here in a bulleted list.

--- a/docs/rules/react-prefer-private-members.md
+++ b/docs/rules/react-prefer-private-members.md
@@ -6,22 +6,59 @@ This rule enforces all non-React-specific members be marked private in React cla
 
 When a member of class is marked private, it cannot be accessed from outside of its containing class. This restriction is prefered when writing React components, where encapsulation is almost always desireable.
 
-Examples of **incorrect** code for this rule:
+The following patterns are considered warnings:
 
-```js
-
-// fill me in
-
+```ts
+class MyComponent extends React.Component<Props, State> {
+  publicMethod() {}
+  alsoPublic: string;
+}
 ```
 
-Examples of **correct** code for this rule:
+The following patterns are not warnings:
+```ts
+class MyComponent extends React.Component<Props, State> {
+  private publicMethod() {}
+  private alsoPublic: string;
+}
+```
 
-```js
+The Lifecycle methods and static properties that are part of the React API are not required to be private for this rule.
 
-// fill me in
+```ts
+class MyComponent extends React.Component<Props, State> {
+  private publicMethod() {}
+  private alsoPublic: string;
+  static propTypes = {}
+  static defaultProps = {}
+  static childContextTypes = {}
+  static contextTypes = {}
+  getDerivedStateFromProps() {}
+  componentWillMount() {}
+  UNSAFE_componentWillMount() {}
+  componentDidMount() {}
+  componentWillReceiveProps() {}
+  UNSAFE_componentWillReceiveProps() {}
+  shouldComponentUpdate() {}
+  componentWillUpdate() {}
+  UNSAFE_componentWillUpdate() {}
+  getSnapshotBeforeUpdate() {}
+  componentDidUpdate() {}
+  componentDidCatch() {}
+  componentWillUnmount() {}
+  render() {}
+}
+```
 
+Exposing subcomponents as public static members is not considered a warning for this rule.
+
+```ts
+class MyComponent extends React.Component<Props, State> {
+  static MySubComponent = MySubComponent;
+  render() {}
+}
 ```
 
 ## When Not To Use It
 
-Give a short description of when it would be appropriate to turn off this rule.
+If you do not want to restrict public members on React class components, you can safely disable this rule.

--- a/lib/rules/react-prefer-private-members.js
+++ b/lib/rules/react-prefer-private-members.js
@@ -4,7 +4,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'Disallow public members within React component classes',
-      category: 'Possible Errors',
+      category: 'Best Practices',
       recommended: true,
       uri:
         'https://github.com/Shopify/eslint-plugin-shopify/blob/master/docs/rules/react-prefer-private-members.md',
@@ -14,6 +14,18 @@ module.exports = {
   create: Components.detect((context, components, utils) => {
     let isES6Component = false;
     let componentName = null;
+
+    function report({node, componentName: classComponent}) {
+      const {
+        key: {name},
+      } = node;
+
+      context.report({
+        node,
+        message: `'{{name}}' should be a private member of '{{classComponent}}'.`,
+        data: {name, classComponent},
+      });
+    }
 
     return {
       ClassDeclaration(node) {
@@ -25,28 +37,18 @@ module.exports = {
           return;
         }
 
-        context.report(makeReport(node, {componentName}));
+        report({node, componentName});
       },
       MethodDefinition(node) {
         if (!isES6Component || isValid(node)) {
           return;
         }
 
-        context.report(makeReport(node, {componentName}));
+        report({node, componentName});
       },
     };
   }),
 };
-
-function makeReport(node, {componentName}) {
-  const {
-    key: {name},
-  } = node;
-  return {
-    node,
-    message: `${name} should be a private member of ${componentName}.`,
-  };
-}
 
 function isValid(node) {
   return (

--- a/lib/rules/react-prefer-private-members.js
+++ b/lib/rules/react-prefer-private-members.js
@@ -1,0 +1,85 @@
+const Components = require('eslint-plugin-react/lib/util/Components');
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow public members within React component classes',
+      category: 'Possible Errors',
+      recommended: true,
+      uri:
+        'https://github.com/Shopify/eslint-plugin-shopify/blob/master/docs/rules/react-prefer-private-members.md',
+    },
+  },
+
+  create: Components.detect((context, components, utils) => {
+    let isES6Component = false;
+    let componentName = null;
+
+    return {
+      ClassDeclaration(node) {
+        isES6Component = utils.isES6Component(node);
+        componentName = node.id.name;
+      },
+      ClassProperty(node) {
+        if (!isES6Component || isValid(node)) {
+          return;
+        }
+
+        context.report(makeReport(node, {componentName}));
+      },
+      MethodDefinition(node) {
+        if (!isES6Component || isValid(node)) {
+          return;
+        }
+
+        context.report(makeReport(node, {componentName}));
+      },
+    };
+  }),
+};
+
+function makeReport(node, {componentName}) {
+  const {
+    key: {name},
+  } = node;
+  return {
+    node,
+    message: `${name} should be a private member of ${componentName}.`,
+  };
+}
+
+function isValid(node) {
+  return (
+    node.accessibility === 'private' ||
+    isReactLifeCycleMethod(node) ||
+    isReactStaticProperty(node)
+  );
+}
+
+function isReactLifeCycleMethod({key: {name}}) {
+  return [
+    'getDerivedStateFromProps',
+    'componentWillMount',
+    'UNSAFE_componentWillMount',
+    'componentDidMount',
+    'componentWillReceiveProps',
+    'UNSAFE_componentWillReceiveProps',
+    'shouldComponentUpdate',
+    'componentWillUpdate',
+    'UNSAFE_componentWillUpdate',
+    'getSnapshotBeforeUpdate',
+    'componentDidUpdate',
+    'componentDidCatch',
+    'componentWillUnmount',
+    'render',
+  ].some((method) => method === name);
+}
+
+function isReactStaticProperty({key: {name}}) {
+  return [
+    'propTypes',
+    'contextTypes',
+    'childContextTypes',
+    'defaultProps',
+  ].some((method) => method === name);
+}

--- a/lib/rules/react-prefer-private-members.js
+++ b/lib/rules/react-prefer-private-members.js
@@ -1,3 +1,4 @@
+const pascalCase = require('pascal-case');
 const Components = require('eslint-plugin-react/lib/util/Components');
 
 module.exports = {
@@ -54,7 +55,8 @@ function isValid(node) {
   return (
     node.accessibility === 'private' ||
     isReactLifeCycleMethod(node) ||
-    isReactStaticProperty(node)
+    isReactStaticProperty(node) ||
+    isCompoundComponentMember(node)
   );
 }
 
@@ -84,4 +86,8 @@ function isReactStaticProperty({key: {name}}) {
     'childContextTypes',
     'defaultProps',
   ].some((method) => method === name);
+}
+
+function isCompoundComponentMember({key: {name}}) {
+  return name === pascalCase(name);
 }

--- a/tests/lib/rules/react-prefer-private-members.js
+++ b/tests/lib/rules/react-prefer-private-members.js
@@ -121,5 +121,19 @@ ruleTester.run('react-prefer-private-members', rule, {
         }),
       ],
     },
+    {
+      code: `class PureButton extends React.PureComponent {
+        publicMethod() {}
+        componentDidMount() {}
+      }`,
+      parser: babelParser,
+      errors: [
+        makeError({
+          type: 'MethodDefinition',
+          memberName: 'publicMethod',
+          componentName: 'PureButton',
+        }),
+      ],
+    },
   ],
 });

--- a/tests/lib/rules/react-prefer-private-members.js
+++ b/tests/lib/rules/react-prefer-private-members.js
@@ -13,7 +13,7 @@ function makeError({type = 'ClassProperty', memberName, componentName}) {
   return [
     {
       type,
-      message: `${memberName} should be a private member of ${componentName}.`,
+      message: `'${memberName}' should be a private member of '${componentName}'.`,
     },
   ];
 }

--- a/tests/lib/rules/react-prefer-private-members.js
+++ b/tests/lib/rules/react-prefer-private-members.js
@@ -1,0 +1,87 @@
+const {RuleTester} = require('eslint');
+const rule = require('../../../lib/rules/react-prefer-private-members');
+
+const ruleTester = new RuleTester();
+
+require('babel-eslint');
+require('typescript-eslint-parser');
+
+const babelParser = 'babel-eslint';
+const typeScriptParser = 'typescript-eslint-parser';
+
+function makeError({type = 'ClassProperty', memberName, componentName}) {
+  return [
+    {
+      type,
+      message: `${memberName} should be a private member of ${componentName}.`,
+    },
+  ];
+}
+
+ruleTester.run('react-prefer-private-members', rule, {
+  valid: [
+    {
+      code: `class Button extends React.Component {
+        private member = true;
+        componentDidMount() {}
+      }`,
+      parser: typeScriptParser,
+    },
+    {
+      code: `class Button extends Klass {
+        publicMember = true
+        publicMethod() {}
+      }`,
+      parser: babelParser,
+    },
+    {
+      code: 'class Button extends React.Component {}',
+      parser: babelParser,
+    },
+    {
+      code: `class KitchenSink extends React.Component {
+        static propTypes = {}
+        static defaultProps = {}
+        static childContextTypes = {}
+        static contextTypes = {}
+        getDerivedStateFromProps() {}
+        componentWillMount() {}
+        UNSAFE_componentWillMount() {}
+        componentDidMount() {}
+        componentWillReceiveProps() {}
+        UNSAFE_componentWillReceiveProps() {}
+        shouldComponentUpdate() {}
+        componentWillUpdate() {}
+        UNSAFE_componentWillUpdate() {}
+        getSnapshotBeforeUpdate() {}
+        componentDidUpdate() {}
+        componentDidCatch() {}
+        componentWillUnmount() {}
+        render() {}
+      }`,
+      parser: babelParser,
+    },
+  ],
+  invalid: [
+    {
+      code: `class Button extends React.Component {
+        publicMember = true;
+        componentDidMount() {}
+      }`,
+      parser: babelParser,
+      errors: makeError({memberName: 'publicMember', componentName: 'Button'}),
+    },
+    {
+      code: `class Button extends React.Component {
+        publicMethod() {}
+        componentDidMount() {}
+      }`,
+      parser: babelParser,
+      errors: makeError({
+        type: 'MethodDefinition',
+        memberName: 'publicMethod',
+        componentName: 'Button',
+      }),
+    },
+  ],
+});


### PR DESCRIPTION
Addresses one of the points here https://github.com/Shopify/eslint-plugin-shopify/issues/77 by looking for React class components and making sure they do not have private members. React API stuff will pass through. Will fill in the docs once the general approach is approved.