### PR TITLE
Use eslint-plugin-sort-class-members 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
-## Unreleased
+## [22.1.0] - 2018-06-08
+
+### Fixed
+* Updated `eslint-plugin-sort-class-members` dependency to version 1.3.1 in order to support node 10.
 
 ### Added
 * `shopify/prefer-pascal-case-enums` ([#96](https://github.com/Shopify/eslint-plugin-shopify/pull/96))

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "eslint-plugin-prettier": "2.6.0",
     "eslint-plugin-promise": "3.7.0",
     "eslint-plugin-react": "7.7.0",
-    "eslint-plugin-sort-class-members": "1.3.0",
+    "eslint-plugin-sort-class-members": "1.3.1",
     "eslint-plugin-typescript": "0.10.0",
     "merge": "1.2.0",
     "pascal-case": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-shopify",
-  "version": "22.0.0",
+  "version": "22.1.0",
   "description": "Shopify’s ESLint rules and configs.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
I was having trouble using this on a project running node `v10.1.0`:

```
The comparison function must be either a function or undefined
TypeError: The comparison function must be either a function or undefined
    at Array.sort (native)
    at getAcceptableSlots (/<project_dir>/node_modules/eslint-plugin-sort-class-members/dist/rules/sort-class-members.js:276:3)
    ...
```
Bumping the version on this dependency fixes the issue.
 