### PR TITLE
Update typescript-eslint-parser version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ eslint-plugin-shopify will no longer install prettier as a dependency. Please en
 
 ### Changed
 * **Breaking** Moved prettier to be a peerDependency, this avoids the potential for having multiple versions of prettier in the dependency graph. If you use prettier you will need to ensure you have it installed in your project as eslint-plugin-shopify will no longer install it for you ([#107](https://github.com/Shopify/eslint-plugin-shopify/pull/107))
+* **Breaking** Updated `typescript-eslint-parser` to support `typescript@2.9.1` ([#102](https://github.com/Shopify/eslint-plugin-shopify/pull/102))
 
 ## [22.1.0] - 2018-06-08
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "merge": "1.2.0",
     "pascal-case": "^2.0.1",
     "pkg-dir": "2.0.0",
-    "typescript-eslint-parser": "15.0.0"
+    "typescript-eslint-parser": "16.0.1"
   }
 }


### PR DESCRIPTION
Let's update `typescript-eslint-parser` and get rid of this error:
```
=============

WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-eslint-parser.
You may find that it works just fine, or you may not.
SUPPORTED TYPESCRIPT VERSIONS: ~2.8.1

YOUR TYPESCRIPT VERSION: 2.9.2

Please only submit bug reports when using the officially supported version.

=============
```

🎩 instructions:
1. Replace your version of `eslint-plugin-shopify` with a link to this branch.
```json
{
  "eslint-plugin-shopify": "git+https://github.com/Shopify/eslint-plugin-shopify.git#fix/bump-ts-eslint-parser",
}
```
2. Run `yarn install`.
3. Running eslint should no longer throw an error.