### PR TITLE
Adds properties to `react-prefer-private-members`

### DIFF
--- a/lib/rules/react-prefer-private-members.js
+++ b/lib/rules/react-prefer-private-members.js
@@ -56,6 +56,7 @@ function isValid(node) {
     node.accessibility === 'private' ||
     isReactLifeCycleMethod(node) ||
     isReactStaticProperty(node) ||
+    isConstructor(node) ||
     isCompoundComponentMember(node)
   );
 }
@@ -75,6 +76,9 @@ function isReactLifeCycleMethod({key: {name}}) {
     'componentDidUpdate',
     'componentDidCatch',
     'componentWillUnmount',
+    'getChildContext',
+    'context',
+    'state',
     'render',
   ].some((method) => method === name);
 }
@@ -85,7 +89,12 @@ function isReactStaticProperty({key: {name}}) {
     'contextTypes',
     'childContextTypes',
     'defaultProps',
+    'displayName',
   ].some((method) => method === name);
+}
+
+function isConstructor({kind}) {
+  return kind === 'constructor';
 }
 
 function isCompoundComponentMember({key: {name}}) {

--- a/tests/lib/rules/react-prefer-private-members.js
+++ b/tests/lib/rules/react-prefer-private-members.js
@@ -42,6 +42,10 @@ ruleTester.run('react-prefer-private-members', rule, {
         static defaultProps = {}
         static childContextTypes = {}
         static contextTypes = {}
+        static displayName = ''
+        state = {}
+        constructor() {}
+        getChildContext() {}
         getDerivedStateFromProps() {}
         componentWillMount() {}
         UNSAFE_componentWillMount() {}


### PR DESCRIPTION
Turning this rule on in `web` revealed a few missed properties. This PR adds them. 