### PR TITLE
Move prettier to be a peer dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,15 @@
 
 ## Unreleased
 
+eslint-plugin-shopify will no longer install prettier as a dependency. Please ensure you have added prettier to your package.json if you wish to use it.
+
 ### Added
 * `shopify/jsx-prefer-fragment-wrappers` ([#94](https://github.com/Shopify/eslint-plugin-shopify/pull/94))
 * `shopify/jest/no-vague-titles` ([#93](https://github.com/Shopify/eslint-plugin-shopify/pull/93))
 * `shopify/strict-component-boundaries` ([#98](https://github.com/Shopify/eslint-plugin-shopify/pull/98))
+
+### Changed
+* **Breaking** Moved prettier to be a peerDependency, this avoids the potential for having multiple versions of prettier in the dependency graph. If you use prettier you will need to ensure you have it installed in your project as eslint-plugin-shopify will no longer install it for you ([#107](https://github.com/Shopify/eslint-plugin-shopify/pull/107))
 
 ## [22.1.0] - 2018-06-08
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ This plugin also provides the following tool-specific configurations, which can 
 - [flow](lib/config/flow.js): Use this for projects that use [flow](http://flowtype.org) for type checking.
 - [jquery](lib/config/jquery.js): Use this for projects that use [jQuery](http://jquery.com).
 - [polaris](lib/config/polaris.js): Use this for projects that use [Shopify’s React Polaris components](https://polaris.shopify.com/components/get-started).
-- [prettier](lib/config/prettier.js): Use [prettier](https://github.com/prettier/prettier) for consistent formatting. Extending this Shopify's prettier config will [override](https://github.com/prettier/eslint-config-prettier/blob/master/index.js) the default Shopify eslint rules in favor of prettier formatting.
-- [typescript-prettier](lib/config/typescript-prettier.js): Use [prettier](https://github.com/prettier/prettier) on typescript projects.
+- [prettier](lib/config/prettier.js): Use [prettier](https://github.com/prettier/prettier) for consistent formatting. Extending this Shopify's prettier config will [override](https://github.com/prettier/eslint-config-prettier/blob/master/index.js) the default Shopify eslint rules in favor of prettier formatting. Prettier must be installed within your project, as eslint-plugin-shopify does not provide the dependency itself.
+- [typescript-prettier](lib/config/typescript-prettier.js): Use [prettier](https://github.com/prettier/prettier) on typescript projects. Prettier must be installed within your project, as eslint-plugin-shopify does not provide the dependency itself.
 - [webpack](lib/config/webpack.js): Use this for projects built by [webpack](https://webpack.js.org/).
 
 ### node

--- a/package.json
+++ b/package.json
@@ -74,9 +74,7 @@
     "typescript": "^2.8.3"
   },
   "peerDependencies": {
-    "eslint": "<5 >=4.7.1"
-  },
-  "optionalDependencies": {
+    "eslint": "<5 >=4.7.1",
     "prettier": "^1.12.1"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,7 +1569,7 @@ eslint-plugin-react@7.7.0:
     prop-types "^15.6.0"
 
 "eslint-plugin-shopify@file:./.":
-  version "22.0.0"
+  version "22.1.0"
   dependencies:
     babel-eslint "8.2.3"
     eslint-config-prettier "2.9.0"
@@ -1587,17 +1587,16 @@ eslint-plugin-react@7.7.0:
     eslint-plugin-prettier "2.6.0"
     eslint-plugin-promise "3.7.0"
     eslint-plugin-react "7.7.0"
-    eslint-plugin-sort-class-members "1.3.0"
+    eslint-plugin-sort-class-members "1.3.1"
     eslint-plugin-typescript "0.10.0"
     merge "1.2.0"
+    pascal-case "^2.0.1"
     pkg-dir "2.0.0"
     typescript-eslint-parser "15.0.0"
-  optionalDependencies:
-    prettier "^1.12.1"
 
-eslint-plugin-sort-class-members@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.3.0.tgz#8a3db9afb84351f06fe3d1622abcafa1e5781694"
+eslint-plugin-sort-class-members@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.3.1.tgz#36a1790855cbd971d9f49701b4aadc2e1ccb83c6"
 
 eslint-plugin-typescript@0.10.0:
   version "0.10.0"


### PR DESCRIPTION
Helping along with https://github.com/Shopify/sewing-kit/issues/737. We should strive to have a single prettier install underneath sewing-kit, rather than multiple dependencies potentially installing multiple prettier versions which leads to confusion around different formatting tools producing different results.

eslint-plugin-prettier expects prettier to be a peer dependency, so do the same here.

