### PR TITLE
Fixes `no-vague-titles`

### DIFF
--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -51,9 +51,11 @@ module.exports = {
 };
 
 function notTestFunction({callee}) {
-  return callee.name
-    ? !matchTestFunctionName(callee.name)
-    : !matchTestFunctionName(callee.object.name);
+  if (callee.name) {
+    return !matchTestFunctionName(callee.name);
+  }
+
+  return callee.object && !matchTestFunctionName(callee.object.name);
 }
 
 function matchTestFunctionName(functionName) {

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -101,6 +101,10 @@ ruleTester.run('no-vague-titles', rule, {
       code: `someFunction.only('correct')`,
       parser,
     },
+    {
+      code: `(() => {})()`,
+      parser,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
This error came up when testing in `web`. A minor fix to prevent reading `name` from a potentially undefined `callee.object`.