### PR TITLE
Add 'all' to vague terms in no-vague-titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Changed
+* Included `all` as a vague term for `no-vague-titles` ([#114](https://github.com/Shopify/eslint-plugin-shopify/pull/114))
+
 ## [23.0.0] - 2018-07-16
 * **Breaking** `eslint-plugin-shopify` will no longer install `prettier` as a dependency. Please ensure you have added `prettier` to your `package.json` if you wish to use it.
 

--- a/docs/rules/jest/no-vague-titles.md
+++ b/docs/rules/jest/no-vague-titles.md
@@ -1,5 +1,11 @@
 # Prevent the usage of vague words in test statements. (no-vague-titles)
-This rule encourages more explicit test descriptions by preventing the use of the vague words, such as "correct" and "appropriate".
+This rule encourages more explicit test descriptions by preventing the use of the vague words.
+
+The following vague terms are flagged:
+
+* "correct"
+* "appropriate"
+* "all"
 
 ## Rule Details
 
@@ -9,6 +15,7 @@ Examples of **incorrect** code for this rule:
 
 ```js
 it('is called with the correct parameters')
+it('is called with all the plugins')
 test('renders the appropriate markup')
 describe('receives the correct props')
 
@@ -18,6 +25,7 @@ Examples of **correct** code for this rule:
 
 ```js
 it(`is called with the user's id and password`)
+it('is called with the Foo and Bar plugins')
 test('renders the user avatar and email')
 describe('receives the date and publishState props from the router params')
 ```

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -94,6 +94,6 @@ function getDescription({arguments: args}) {
 }
 
 function containsVagueWord(description) {
-  const vagueTerms = [/correct/i, /appropriate/i, /all/i];
+  const vagueTerms = [/correct/i, /appropriate/i, /( )*all(\.|\s)/i];
   return vagueTerms.find((term) => description.match(term));
 }

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -94,5 +94,6 @@ function getDescription({arguments: args}) {
 }
 
 function containsVagueWord(description) {
-  return description.match(/correct/i) || description.match(/appropriate/i);
+  const vagueTerms = [/correct/i, /appropriate/i, /all/i];
+  return vagueTerms.find((term) => description.match(term));
 }

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -102,6 +102,18 @@ ruleTester.run('no-vague-titles', rule, {
       parser,
     },
     {
+      code: `someFunction('all')`,
+      parser,
+    },
+    {
+      code: `someFunction('All')`,
+      parser,
+    },
+    {
+      code: `someFunction.only('all')`,
+      parser,
+    },
+    {
       code: `(() => {})()`,
       parser,
     },
@@ -128,31 +140,6 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('it'),
     },
     {
-      code: "it.only('correct')",
-      parser,
-      errors: errorWithMethod('it'),
-    },
-    {
-      code: "it.only('correctly')",
-      parser,
-      errors: errorWithMethod('it'),
-    },
-    {
-      code: "it.only('incorrect')",
-      parser,
-      errors: errorWithMethod('it'),
-    },
-    {
-      code: "it.only('Correct')",
-      parser,
-      errors: errorWithMethod('it'),
-    },
-    {
-      code: "xit('correct')",
-      parser,
-      errors: errorWithMethod('xit'),
-    },
-    {
       code: "xit('correctly')",
       parser,
       errors: errorWithMethod('xit'),
@@ -168,12 +155,17 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xit'),
     },
     {
+      code: "xit('All')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
       code: "describe('correct')",
       parser,
       errors: errorWithMethod('describe'),
     },
     {
-      code: "describe('correct')",
+      code: "describe('all')",
       parser,
       errors: errorWithMethod('describe'),
     },
@@ -198,7 +190,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xdescribe'),
     },
     {
-      code: "xdescribe('correct')",
+      code: "xdescribe('all')",
       parser,
       errors: errorWithMethod('xdescribe'),
     },
@@ -217,11 +209,13 @@ ruleTester.run('no-vague-titles', rule, {
       parser,
       errors: errorWithMethod('xdescribe'),
     },
+
     {
       code: "describe.only('correct')",
       parser,
       errors: errorWithMethod('describe'),
     },
+
     {
       code: "describe.only('correctly')",
       parser,
@@ -238,9 +232,9 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('describe'),
     },
     {
-      code: "test('correct')",
+      code: "describe.only('All')",
       parser,
-      errors: errorWithMethod('test'),
+      errors: errorWithMethod('describe'),
     },
     {
       code: "test('correct')",
@@ -262,13 +256,14 @@ ruleTester.run('no-vague-titles', rule, {
       parser,
       errors: errorWithMethod('test'),
     },
+
     {
       code: "xtest('correct')",
       parser,
       errors: errorWithMethod('xtest'),
     },
     {
-      code: "xtest('correct')",
+      code: "xtest('all')",
       parser,
       errors: errorWithMethod('xtest'),
     },
@@ -471,6 +466,81 @@ ruleTester.run('no-vague-titles', rule, {
       code: "xtest('Appropriate')",
       parser,
       errors: errorWithMethod('xtest'),
+    },
+    {
+      code: "it('all')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it('All')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('correct')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('all')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('correctly')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('incorrect')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('Correct')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "it.only('All')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "xit('correct')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "xit('all')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: "describe('All')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "xdescribe('All')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "describe.only('all')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "test('All')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "test.only('all')",
+      parser,
+      errors: errorWithMethod('test'),
     },
   ],
 });

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -102,20 +102,26 @@ ruleTester.run('no-vague-titles', rule, {
       parser,
     },
     {
-      code: `someFunction('all')`,
+      code: `someFunction('Includes all the expected things')`,
       parser,
     },
     {
-      code: `someFunction('All')`,
+      code: `someFunction('All the expected things are included')`,
       parser,
     },
     {
-      code: `someFunction.only('all')`,
+      code: `someFunction.only('Includes all the expected things')`,
       parser,
     },
     {
       code: `(() => {})()`,
       parser,
+    },
+
+    {
+      code: "it('onAllImagesUploaded')",
+      parser,
+      errors: errorWithMethod('it'),
     },
   ],
   invalid: [
@@ -155,7 +161,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xit'),
     },
     {
-      code: "xit('All')",
+      code: "xit('All the expected things are included')",
       parser,
       errors: errorWithMethod('xit'),
     },
@@ -165,7 +171,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('describe'),
     },
     {
-      code: "describe('all')",
+      code: "describe('Includes all the expected things')",
       parser,
       errors: errorWithMethod('describe'),
     },
@@ -190,7 +196,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xdescribe'),
     },
     {
-      code: "xdescribe('all')",
+      code: "xdescribe('Includes all the expected things')",
       parser,
       errors: errorWithMethod('xdescribe'),
     },
@@ -232,7 +238,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('describe'),
     },
     {
-      code: "describe.only('All')",
+      code: "describe.only('Includes all the expected things')",
       parser,
       errors: errorWithMethod('describe'),
     },
@@ -263,7 +269,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xtest'),
     },
     {
-      code: "xtest('all')",
+      code: "xtest('Includes all the expected things')",
       parser,
       errors: errorWithMethod('xtest'),
     },
@@ -468,12 +474,12 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xtest'),
     },
     {
-      code: "it('all')",
+      code: "it('Includes all the expected things')",
       parser,
       errors: errorWithMethod('it'),
     },
     {
-      code: "it('All')",
+      code: "it('All the expected things are included')",
       parser,
       errors: errorWithMethod('it'),
     },
@@ -483,7 +489,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('it'),
     },
     {
-      code: "it.only('all')",
+      code: "it.only('Includes all the expected things')",
       parser,
       errors: errorWithMethod('it'),
     },
@@ -503,7 +509,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('it'),
     },
     {
-      code: "it.only('All')",
+      code: "it.only('All the expected things are included')",
       parser,
       errors: errorWithMethod('it'),
     },
@@ -513,32 +519,32 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xit'),
     },
     {
-      code: "xit('all')",
+      code: "xit('Includes all the expected things')",
       parser,
       errors: errorWithMethod('xit'),
     },
     {
-      code: "describe('All')",
+      code: "describe('All the expected things are included')",
       parser,
       errors: errorWithMethod('describe'),
     },
     {
-      code: "xdescribe('All')",
+      code: "xdescribe('All the expected things are included')",
       parser,
       errors: errorWithMethod('xdescribe'),
     },
     {
-      code: "describe.only('all')",
+      code: "describe.only('Includes all the expected things')",
       parser,
       errors: errorWithMethod('describe'),
     },
     {
-      code: "test('All')",
+      code: "test('All the expected things are included')",
       parser,
       errors: errorWithMethod('test'),
     },
     {
-      code: "test.only('all')",
+      code: "test.only('Includes all the expected things')",
       parser,
       errors: errorWithMethod('test'),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1569,7 +1569,7 @@ eslint-plugin-react@7.7.0:
     prop-types "^15.6.0"
 
 "eslint-plugin-shopify@file:./.":
-  version "22.1.0"
+  version "23.0.0"
   dependencies:
     babel-eslint "8.2.3"
     eslint-config-prettier "2.9.0"
@@ -1592,7 +1592,7 @@ eslint-plugin-react@7.7.0:
     merge "1.2.0"
     pascal-case "^2.0.1"
     pkg-dir "2.0.0"
-    typescript-eslint-parser "15.0.0"
+    typescript-eslint-parser "16.0.1"
 
 eslint-plugin-sort-class-members@1.3.1:
   version "1.3.1"
@@ -3529,9 +3529,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-15.0.0.tgz#882fd3d7aabffbab0a7f98d2a59fb9a989c2b37f"
+typescript-eslint-parser@16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz#b40681c7043b222b9772748b700a000b241c031b"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"


### PR DESCRIPTION
I think we should also flag `all` as a vague term. Noticed this while reviewing https://github.com/Shopify/sewing-kit/pull/755.