### PR TITLE
Remove inline Prettier configs (fixes #118)

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,6 @@
   "singleQuote": true,
   "bracketSpacing": false,
   "trailingComma": "all",
+  "jsxBracketSameLine": false,
   "arrowParens": "always"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+* Updated `typescript-eslint-parser` dependency to version 17.0.1 in order to support TypeScript 3.
+* `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` now defer Prettier's config to project's `.prettierrc`.
+
 ### Changed
 * Included `all` as a vague term for `no-vague-titles` ([#114](https://github.com/Shopify/eslint-plugin-shopify/pull/114))
 

--- a/lib/config/prettier.js
+++ b/lib/config/prettier.js
@@ -4,17 +4,6 @@ module.exports = {
   plugins: ['prettier'],
 
   rules: {
-    'prettier/prettier': [
-      'error',
-      {
-        singleQuote: true,
-        trailingComma: 'all',
-        bracketSpacing: false,
-        jsxBracketSameLine: false,
-        arrowParens: 'always',
-      },
-    ],
-
     // rules to disable to prefer prettier
     'shopify/binary-assignment-parens': 'off',
     'babel/semi': 'off',

--- a/lib/config/typescript-prettier.js
+++ b/lib/config/typescript-prettier.js
@@ -6,10 +6,6 @@ module.exports = {
       'error',
       {
         parser: 'typescript',
-        singleQuote: true,
-        trailingComma: 'all',
-        bracketSpacing: false,
-        jsxBracketSameLine: false,
       },
     ],
   },

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "merge": "1.2.0",
     "pascal-case": "^2.0.1",
     "pkg-dir": "2.0.0",
-    "typescript-eslint-parser": "16.0.1"
+    "typescript-eslint-parser": "17.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1592,7 +1592,7 @@ eslint-plugin-react@7.7.0:
     merge "1.2.0"
     pascal-case "^2.0.1"
     pkg-dir "2.0.0"
-    typescript-eslint-parser "16.0.1"
+    typescript-eslint-parser "17.0.1"
 
 eslint-plugin-sort-class-members@1.3.1:
   version "1.3.1"
@@ -3529,9 +3529,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@16.0.1:
-  version "16.0.1"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-16.0.1.tgz#b40681c7043b222b9772748b700a000b241c031b"
+typescript-eslint-parser@17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-17.0.1.tgz#ddc681a3afa51a9baa6746a001eb5f29fb1365d3"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"


### PR DESCRIPTION
Theoretically no breaking changes. The TypeScript parser upgrade fixes deprecated API calls broken for TypeScript 3.