### PR TITLE
Fix semicolon rules conflicting with Prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!-- ## Unreleased -->
+### Fixed
+* `plugin:shopify/flow` now disables rules checked by Flow's static analyzer. ([#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135))
+* `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` defer missing semicolon rules to a project´s `.prettierrc`. ([#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135))
+
 ### Added
 * `shopify/prefer-singular-enums` ([#132](https://github.com/Shopify/eslint-plugin-shopify/pull/132))
 

--- a/lib/config/prettier.js
+++ b/lib/config/prettier.js
@@ -5,6 +5,7 @@ module.exports = {
 
   rules: {
     // rules to disable to prefer prettier
+    'shopify/class-property-semi': 'off',
     'shopify/binary-assignment-parens': 'off',
     'babel/semi': 'off',
 

--- a/lib/config/rules/flowtype.js
+++ b/lib/config/rules/flowtype.js
@@ -54,4 +54,12 @@ module.exports = {
   'flowtype/use-flow-type': 'error',
   // Checks for simple Flow syntax errors.
   'flowtype/valid-syntax': 'error',
+
+  // Already supported by Flow
+  'no-undef': 'off',
+  'no-unused-expressions': 'off',
+  'no-unused-vars': 'off',
+  'no-useless-constructor': 'off',
+  'no-shadow': 'off',
+  'no-use-before-define': 'off',
 };

--- a/lib/config/typescript-prettier.js
+++ b/lib/config/typescript-prettier.js
@@ -2,6 +2,9 @@ module.exports = {
   extends: ['plugin:shopify/prettier'],
 
   rules: {
+    // rules to disable to prefer prettier
+    'typescript/member-delimiter-style': 'off',
+
     'prettier/prettier': [
       'error',
       {


### PR DESCRIPTION
I believe the only changes in behavior legitimately didn't work before. The changes to Flow were copied from TypeScript. The changes for Prettier could be checked by an integration test with a `.prettierrc` configured opposite of Shopify's.