### PR TITLE
Adds support for describe.each to no-vague-titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 ### Fixed
 * `plugin:shopify/flow` now disables rules checked by Flow's static analyzer. ([#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135))
 * `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` defer missing semicolon rules to a project´s `.prettierrc`. ([#135](https://github.com/Shopify/eslint-plugin-shopify/pull/135))
-* Updated `strict-component-boundaries` to exclude fixture imports([#117](https://github.com/Shopify/eslint-plugin-shopify/pull/117))
-* Updated `strict-component-boundaries` to exclude imports from node_modules([#140](https://github.com/Shopify/eslint-plugin-shopify/pull/140))
+* Updated `strict-component-boundaries` to exclude fixture imports. ([#117](https://github.com/Shopify/eslint-plugin-shopify/pull/117))
+* Updated `strict-component-boundaries` to exclude imports from node_modules. ([#140](https://github.com/Shopify/eslint-plugin-shopify/pull/140))
+* Updated `jest/no-vague-titles` to support `.each` syntax. ([#148](https://github.com/Shopify/eslint-plugin-shopify/pull/148))
 
 ### Changed
 * Namespaced `prefer-pascal-case-enums` and `prefer-singular-enums` under `typescript`. ([#141](https://github.com/Shopify/eslint-plugin-shopify/pull/141))

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -75,15 +75,18 @@ function hasEmptyDescription({arguments: args}) {
 }
 
 function getMethodName({callee}) {
-  if (callee.name) {
-    return callee.name;
+  switch (callee.type) {
+    case 'CallExpression':
+      return callee.callee.object.name;
+    case 'Identifier':
+      return callee.name;
+    case 'MemberExpression':
+      return callee.object.name;
+    case 'ArrowFunctionExpression':
+      return '';
+    default:
+      throw new Error('Could not get method name from node.');
   }
-
-  if (callee.object) {
-    return callee.object.name;
-  }
-
-  return callee.type === 'CallExpression' && callee.callee.object.name;
 }
 
 function getDescription({arguments: args}) {

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -11,11 +11,9 @@ module.exports = {
   create(context) {
     const ignored = (context.options[0] && context.options[0].ignore) || [];
 
-    function isIgnoredFunctionName({callee}) {
-      return ignored.some(
-        (method) =>
-          callee.name ? method === callee.name : method === callee.object.name,
-      );
+    function isIgnoredFunctionName(node) {
+      const method = getMethodName(node);
+      return ignored.some((ignoredMethod) => ignoredMethod === method);
     }
 
     function validate(node) {
@@ -30,12 +28,12 @@ module.exports = {
       const description = getDescription(node);
 
       if (containsVagueWord(description)) {
+        const method = getMethodName(node);
+
         context.report({
           message: `{{ method }} description should not contain vague words. Be sure the description meaningfully illustrates the purpose of this test.`,
           data: {
-            method: node.callee.name
-              ? node.callee.name
-              : node.callee.object.name,
+            method,
           },
           node,
         });
@@ -50,12 +48,9 @@ module.exports = {
   },
 };
 
-function notTestFunction({callee}) {
-  if (callee.name) {
-    return !matchTestFunctionName(callee.name);
-  }
-
-  return callee.object && !matchTestFunctionName(callee.object.name);
+function notTestFunction(node) {
+  const method = getMethodName(node);
+  return !matchTestFunctionName(method);
 }
 
 function matchTestFunctionName(functionName) {
@@ -77,6 +72,18 @@ function hasEmptyDescription({arguments: args}) {
     !args[0] ||
     (args[0].type !== 'Literal' && args[0].type !== 'TemplateLiteral')
   );
+}
+
+function getMethodName({callee}) {
+  if (callee.name) {
+    return callee.name;
+  }
+
+  if (callee.object) {
+    return callee.object.name;
+  }
+
+  return callee.type === 'CallExpression' && callee.callee.object.name;
 }
 
 function getDescription({arguments: args}) {

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -117,11 +117,13 @@ ruleTester.run('no-vague-titles', rule, {
       code: `(() => {})()`,
       parser,
     },
-
     {
       code: "it('onAllImagesUploaded')",
       parser,
-      errors: errorWithMethod('it'),
+    },
+    {
+      code: `test.each([['production'], ['staging']])('Includes things for %s clients')`,
+      parser,
     },
   ],
   invalid: [
@@ -449,6 +451,11 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('test'),
     },
     {
+      code: `test.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
       code: "xtest('appropriate')",
       parser,
       errors: errorWithMethod('xtest'),
@@ -470,6 +477,11 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('Appropriate')",
+      parser,
+      errors: errorWithMethod('xtest'),
+    },
+    {
+      code: `xtest.each([['production'], ['staging']])('Includes all things for %s clients')`,
       parser,
       errors: errorWithMethod('xtest'),
     },
@@ -514,12 +526,22 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('it'),
     },
     {
+      code: `it.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
       code: "xit('correct')",
       parser,
       errors: errorWithMethod('xit'),
     },
     {
       code: "xit('Includes all the expected things')",
+      parser,
+      errors: errorWithMethod('xit'),
+    },
+    {
+      code: `xit.each([['production'], ['staging']])('Includes all things for %s clients')`,
       parser,
       errors: errorWithMethod('xit'),
     },
@@ -534,7 +556,17 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xdescribe'),
     },
     {
+      code: `xdescribe.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
       code: "describe.only('Includes all the expected things')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: `describe.each([['production'], ['staging']])('Includes all things for %s clients')`,
       parser,
       errors: errorWithMethod('describe'),
     },
@@ -548,10 +580,15 @@ ruleTester.run('no-vague-titles', rule, {
       parser,
       errors: errorWithMethod('test'),
     },
+    {
+      code: `test.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      parser,
+      errors: errorWithMethod('test'),
+    },
   ],
 });
 
-ruleTester.run('no-tests-contain-correct with ignore=describe', rule, {
+ruleTester.run('no-vague-titles with ignore=describe', rule, {
   valid: [
     {
       code: "describe('correct')",
@@ -593,11 +630,15 @@ ruleTester.run('no-tests-contain-correct with ignore=describe', rule, {
       code: "describe.only('appropriate')",
       options: [{ignore: ['describe']}],
     },
+    {
+      code: `describe.each([['production'], ['staging']])('Includes things all for %s clients')`,
+      options: [{ignore: ['describe']}],
+    },
   ],
   invalid: [],
 });
 
-ruleTester.run('no-tests-contain-correct with ignore=test', rule, {
+ruleTester.run('no-vague-titles with ignore=test', rule, {
   valid: [
     {
       code: "test('correct')",
@@ -635,11 +676,15 @@ ruleTester.run('no-tests-contain-correct with ignore=test', rule, {
       code: 'test.only("appropriate")',
       options: [{ignore: ['test']}],
     },
+    {
+      code: `test.each([['production'], ['staging']])('Includes things all for %s clients')`,
+      options: [{ignore: ['test']}],
+    },
   ],
   invalid: [],
 });
 
-ruleTester.run('no-tests-contain-correct with ignore=it', rule, {
+ruleTester.run('no-vague-titles with ignore=it', rule, {
   valid: [
     {
       code: "it('correct')",
@@ -675,6 +720,10 @@ ruleTester.run('no-tests-contain-correct with ignore=it', rule, {
     },
     {
       code: 'it.only("appropriate")',
+      options: [{ignore: ['it']}],
+    },
+    {
+      code: `it.each([['production'], ['staging']])('Includes things all for %s clients')`,
       options: [{ignore: ['it']}],
     },
   ],

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -451,7 +451,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('test'),
     },
     {
-      code: `test.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      code: `test.each([['production'], ['staging']])('all correct for %s')`,
       parser,
       errors: errorWithMethod('test'),
     },
@@ -481,7 +481,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xtest'),
     },
     {
-      code: `xtest.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      code: `xtest.each([['production'], ['staging']])('all correct for %s')`,
       parser,
       errors: errorWithMethod('xtest'),
     },
@@ -526,7 +526,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('it'),
     },
     {
-      code: `it.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      code: `it.each([['production'], ['staging']])('all correct for %s')`,
       parser,
       errors: errorWithMethod('it'),
     },
@@ -541,7 +541,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xit'),
     },
     {
-      code: `xit.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      code: `xit.each([['production'], ['staging']])('all correct for %s')`,
       parser,
       errors: errorWithMethod('xit'),
     },
@@ -556,7 +556,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('xdescribe'),
     },
     {
-      code: `xdescribe.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      code: `xdescribe.each([['production'], ['staging']])('all correct for %s')`,
       parser,
       errors: errorWithMethod('xdescribe'),
     },
@@ -566,7 +566,7 @@ ruleTester.run('no-vague-titles', rule, {
       errors: errorWithMethod('describe'),
     },
     {
-      code: `describe.each([['production'], ['staging']])('Includes all things for %s clients')`,
+      code: `describe.each([['production'], ['staging']])('all correct for %s')`,
       parser,
       errors: errorWithMethod('describe'),
     },
@@ -631,7 +631,7 @@ ruleTester.run('no-vague-titles with ignore=describe', rule, {
       options: [{ignore: ['describe']}],
     },
     {
-      code: `describe.each([['production'], ['staging']])('Includes things all for %s clients')`,
+      code: `describe.each([['production'], ['staging']])('all correct for %s')`,
       options: [{ignore: ['describe']}],
     },
   ],
@@ -677,7 +677,7 @@ ruleTester.run('no-vague-titles with ignore=test', rule, {
       options: [{ignore: ['test']}],
     },
     {
-      code: `test.each([['production'], ['staging']])('Includes things all for %s clients')`,
+      code: `test.each([['production'], ['staging']])('all correct for %s')`,
       options: [{ignore: ['test']}],
     },
   ],
@@ -723,7 +723,7 @@ ruleTester.run('no-vague-titles with ignore=it', rule, {
       options: [{ignore: ['it']}],
     },
     {
-      code: `it.each([['production'], ['staging']])('Includes things all for %s clients')`,
+      code: `it.each([['production'], ['staging']])('all correct for %s')`,
       options: [{ignore: ['it']}],
     },
   ],


### PR DESCRIPTION
Closes https://github.com/Shopify/eslint-plugin-shopify/issues/101

This was suddenly more urgent because sewing-kit started writing tests in this style. The lack of support for this feature was causing errors when linting that codebase.