### PR TITLE
Fix ignore `fix-strict-component-boundaries` fixtures folder

### DIFF
--- a/lib/rules/strict-component-boundaries.js
+++ b/lib/rules/strict-component-boundaries.js
@@ -26,9 +26,10 @@ module.exports = {
         }
 
         if (
-          isInvalidFixtureDirectory(pathParts) &&
           ((hasAnotherComponentInPath(pathParts) && pathParts.length > 1) ||
-            (hasComponentDirectoryInPath(pathParts) && pathParts.length > 2))
+            (hasDirectoryInPath(pathParts, 'components') &&
+              pathParts.length > 2)) &&
+          !hasDirectoryInPath(pathParts, 'fixtures')
         ) {
           context.report({
             node,
@@ -48,27 +49,14 @@ function inNodeModules(pathParts) {
   return Boolean(pathParts.filter((part) => part === 'node_modules').length);
 }
 
-function hasComponentDirectoryInPath(pathParts) {
-  return Boolean(pathParts.filter((part) => part === 'components').length);
+function hasDirectoryInPath(pathParts, directory) {
+  return Boolean(pathParts.filter((part) => part === directory).length);
 }
 
 function hasAnotherComponentInPath(pathParts) {
   return Boolean(pathParts.filter((part) => part === pascalCase(part)).length);
 }
+
 function pathSegmantsFromSource(source) {
   return source.split('/').filter((part) => part[0] !== '.');
-}
-
-function isInvalidFixtureDirectory(pathParts) {
-  const fixtureIndex = pathParts.indexOf('fixtures');
-
-  if (fixtureIndex === -1) {
-    return true;
-  }
-
-  const pathBeforeFixture = pathParts.slice(0, fixtureIndex);
-  return (
-    hasComponentDirectoryInPath(pathBeforeFixture) ||
-    hasAnotherComponentInPath(pathBeforeFixture)
-  );
 }

--- a/tests/lib/rules/strict-component-boundaries.js
+++ b/tests/lib/rules/strict-component-boundaries.js
@@ -57,15 +57,5 @@ ruleTester.run('strict-component-boundaries', rule, {
       parserOptions,
       errors,
     },
-    {
-      code: `import someThing from '../SomeComponent/fixtures/SomeMockQuery/query.json';`,
-      parserOptions,
-      errors,
-    },
-    {
-      code: `import someThing from './components/SomeComponent/fixtures/SomeMockQuery/query.json';`,
-      parserOptions,
-      errors,
-    },
   ],
 });


### PR DESCRIPTION
This PR simplifies the fixtures folder check in `strict-component-boundaries`.  In this PR we just check if we are looking inside a fixtures directory and bail if we are. IMO thats all we need.