### PR TITLE
Adds `jsx-require-react` rule

### DIFF
--- a/docs/rules/jsx-require-react.md
+++ b/docs/rules/jsx-require-react.md
@@ -1,0 +1,73 @@
+# Require React import in .jsx and .tsx files. (jsx-require-react)
+
+JSX really just provides syntactic sugar for React's `createElement(component, props, ...children)` function. For example:
+
+```jsx
+<Button color="blue">
+  Click Me
+</Button>
+```
+
+will compile to:
+
+```js
+React.createElement(
+  Button,
+  {color: 'blue'},
+  'Click Me'
+)
+```
+
+Built-in components and self-closing tags compile in the same way. For example:
+
+```jsx
+<div className="fancy" />
+```
+
+will compile to:
+
+```js
+React.createElement(
+  'div',
+  {className: 'fancy'},
+  null
+)
+```
+
+## Rule Details
+
+The requirement to import React can easily be missed because it is not directly referenced when authoring JSX. This rule necessitates that React is imported when working in a .tsx or .jsx files.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+function Card(props) {
+  return (
+    <div>{props.children}</div>
+  )
+};
+export default Card;
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+import React from 'react'
+
+function Card(props) {
+  return (
+    <div>{props.children}</div>
+  )
+};
+export default Card;
+```
+
+## When Not To Use It
+
+If you do not wish to enforce a React import in JSX (perhaps you are loading React from a <script> tag and is therefore in the global scope), you can safely disable this rule.
+
+## Further Reading
+
+* [Online babel compiler](https://babeljs.io/repl/#?presets=react&code_lz=GYVwdgxgLglg9mABACwKYBt1wBQEpEDeAUIogE6pQhlIA8AJjAG4B8AEhlogO5xnr0AhLQD0jVgG4iAXyJA)
+* [JSX in depth](https://reactjs.org/docs/jsx-in-depth.html)
+

--- a/lib/rules/jsx-require-react.js
+++ b/lib/rules/jsx-require-react.js
@@ -1,0 +1,51 @@
+import {extname} from 'path';
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Require React import in .jsx and .tsx files.',
+      category: 'Best Practises',
+      recommended: false,
+      uri:
+        'https://github.com/Shopify/eslint-plugin-shopify/blob/master/docs/rules/jsx-require-react.md',
+    },
+    fixable: null,
+  },
+  create(context) {
+    const reactImports = [];
+    let isTsxOrJsxFile = false;
+
+    function checkFilename() {
+      const fileExtension = extname(context.getFilename());
+      isTsxOrJsxFile = ['.tsx', '.jsx'].some((ext) => ext === fileExtension);
+    }
+
+    function report(node) {
+      context.report({
+        node,
+        message: [
+          `Missing import to React. Since JSX compiles to React.createElement calls,`,
+          `the React library must be in scope when inside {{extname}} files.`,
+        ].join(' '),
+        data: {
+          extname: extname(context.getFilename()),
+        },
+      });
+    }
+
+    return {
+      JSXOpeningElement: checkFilename,
+      JSXOpeningFragment: checkFilename,
+      ImportDeclaration(node) {
+        if (node.source.value === 'react') {
+          reactImports.push(node);
+        }
+      },
+      'Program:exit': function(node) {
+        if (!reactImports.length && isTsxOrJsxFile) {
+          report(node);
+        }
+      },
+    };
+  },
+};

--- a/tests/lib/rules/jsx-require-react.js
+++ b/tests/lib/rules/jsx-require-react.js
@@ -1,0 +1,110 @@
+const {RuleTester} = require('eslint');
+const rule = require('../../../lib/rules/jsx-require-react');
+
+require('babel-eslint');
+
+const parser = 'babel-eslint';
+const ruleTester = new RuleTester();
+function errorWithExt(extname) {
+  return [
+    {
+      message: [
+        `Missing import to React. Since JSX compiles to React.createElement calls,`,
+        `the React library must be in scope when inside ${extname} files.`,
+      ].join(' '),
+    },
+  ];
+}
+
+ruleTester.run('jsx-require-react', rule, {
+  valid: [
+    {
+      code: `
+        import React from 'react';
+        function Card(props) {
+          return (
+            <div>{props.children}</div>
+          )
+        };
+        export default Card;
+      `,
+      parser,
+      filename: 'MyComponent.tsx',
+    },
+    {
+      code: `
+        import React from 'react';
+        function Card(props) {
+          return (
+            <div>{props.children}</div>
+          )
+        };
+        export default Card;
+      `,
+      parser,
+      filename: 'MyComponent.jsx',
+    },
+    {
+      code: `
+        import * as React from 'react';
+        function Card(props) {
+          return (
+            <div>{props.children}</div>
+          )
+        };
+        export default Card;
+      `,
+      parser,
+      filename: 'MyComponent.tsx',
+    },
+    {
+      code: `
+        import * as React from 'react';
+        function Card(props) {
+          return (
+            <div>{props.children}</div>
+          )
+        };
+        export default Card;
+      `,
+      parser,
+      filename: 'MyComponent.jsx',
+    },
+    {
+      code: `
+        function Card(props) {
+          return (
+            <div>{props.children}</div>
+          )
+        };
+        export default Card;`,
+      parser,
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        function Card(props) {
+          return (
+            <div>{props.children}</div>
+          )
+        };
+        export default Card;`,
+      parser,
+      errors: errorWithExt('.tsx'),
+      filename: 'MyComponent.tsx',
+    },
+    {
+      code: `
+        function Card(props) {
+          return (
+            <div>{props.children}</div>
+          )
+        };
+        export default Card;`,
+      parser,
+      errors: errorWithExt('.jsx'),
+      filename: 'MyComponent.jsx',
+    },
+  ],
+});


### PR DESCRIPTION
Closes https://github.com/Shopify/eslint-plugin-shopify/issues/73

This rule enforces a React import when writing JSX. Will follow up with updating the readme, configs, and changelog when the general name and approach is approved.

#### Questions

1. Should we also support `const React = require('react')`.
1. I had a previous version of this rule that takes a different approach. Rather than looking at the filename and ImportDeclaration, it gathered variables with the name React. It was far more confusing but interested if anyone thinks that's a better approach here.
1. Always unsure of the name, so let me know if it is clear.
