### PR TITLE
fix getMethodName issues in no-vague-titles rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+* Updated `no-vague-titles` rule to fix parsing issues in `getMethodName`. ([#167](https://github.com/Shopify/eslint-plugin-shopify/pull/167))
 
 ## [24.1.1] - 2018-09-19
 

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -77,13 +77,19 @@ function hasEmptyDescription({arguments: args}) {
 function getMethodName({callee}) {
   switch (callee.type) {
     case 'CallExpression':
-      return callee.callee.object.name;
+      return callee.callee.object
+        ? callee.callee.object.name
+        : callee.callee.name;
     case 'Identifier':
       return callee.name;
     case 'MemberExpression':
       return callee.object.name;
     case 'ArrowFunctionExpression':
       return '';
+    case 'Import':
+      return 'import';
+    case 'Super':
+      return 'super';
     default:
       throw new Error('Could not get method name from node.');
   }

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -125,6 +125,18 @@ ruleTester.run('no-vague-titles', rule, {
       code: `test.each([['production'], ['staging']])('Includes things for %s clients')`,
       parser,
     },
+    {
+      code: `import('./foo')`,
+      parser,
+    },
+    {
+      code: 'foo(bar)()',
+      parser,
+    },
+    {
+      code: 'class Foo { constructor() { super(); } }',
+      parser,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
this fixes three issues with `getMethodName`
* an `Error: Could not get method name from node.` issue when the linter is parsing an import expression (i.e., `import('./foo')`).
* an `Error: Could not get method name from node.` issue when the linter is parsing a `super` expression (i.e., `super()`).
* a `TypeError: Cannot read property 'name' of undefined` issue when the linter is parsing an objectless call expression (i.e., `foo(bar)()`).