### PR TITLE
adding graphql config to index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+* Added `plugin:shopify/graphql` to module index. ([#000](https://github.com/Shopify/eslint-plugin-shopify/pull/000))
+
 ### Fixed
 
 * Updated `no-vague-titles` rule to fix parsing issues in `getMethodName`. ([#167](https://github.com/Shopify/eslint-plugin-shopify/pull/167))

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = {
     es5: require('./lib/config/es5'),
     esnext: require('./lib/config/esnext'),
     flow: require('./lib/config/flow'),
+    graphql: require('./lib/config/graphql'),
     jest: require('./lib/config/jest'),
     jquery: require('./lib/config/jquery'),
     lodash: require('./lib/config/lodash'),


### PR DESCRIPTION
#165 should have added the `plugin:shopify/graphql` config to the index exports, this PR adds the missing export.