### PR TITLE
updating prettier config to enable the prettier/prettier rule

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 coverage
+tests/fixtures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Fixed
+
+* Updated `plugin:shopify/prettier` to enable prettier linting. ([#170](https://github.com/Shopify/eslint-plugin-shopify/pull/170))
 
 ## [24.2.0] - 2018-09-21
 
 ### Added
 
-* Added `plugin:shopify/graphql` to module index. ([#000](https://github.com/Shopify/eslint-plugin-shopify/pull/000))
+* Added `plugin:shopify/graphql` to module index. ([#168](https://github.com/Shopify/eslint-plugin-shopify/pull/168))
 
 ### Fixed
 

--- a/lib/config/all.js
+++ b/lib/config/all.js
@@ -57,6 +57,7 @@ module.exports = {
     require('./rules/jsx-a11y'),
     require('./rules/lodash'),
     require('./rules/node'),
+    require('./rules/prettier'),
     require('./rules/promise'),
     require('./rules/react'),
     require('./rules/shopify'),

--- a/lib/config/prettier.js
+++ b/lib/config/prettier.js
@@ -1,9 +1,11 @@
+const merge = require('merge');
+
 module.exports = {
   extends: ['prettier'],
 
   plugins: ['prettier'],
 
-  rules: {
+  rules: merge(require('./rules/prettier'), {
     // rules to disable to prefer prettier
     'shopify/class-property-semi': 'off',
     'shopify/binary-assignment-parens': 'off',
@@ -21,5 +23,5 @@ module.exports = {
     // Special rule for 'no-unexpected-multiline'
     // https://github.com/prettier/eslint-config-prettier/blob/5399175c37466747aae9d407021dffec2c169c8b/README.md#no-unexpected-multiline
     'no-unexpected-multiline': 'error',
-  },
+  }),
 };

--- a/lib/config/rules/prettier.js
+++ b/lib/config/rules/prettier.js
@@ -1,0 +1,3 @@
+module.exports = {
+  'prettier/prettier': 'error',
+};

--- a/lib/config/typescript-prettier.js
+++ b/lib/config/typescript-prettier.js
@@ -4,12 +4,5 @@ module.exports = {
   rules: {
     // rules to disable to prefer prettier
     'typescript/member-delimiter-style': 'off',
-
-    'prettier/prettier': [
-      'error',
-      {
-        parser: 'typescript',
-      },
-    ],
   },
 };

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-preset-shopify": "^16.5.0",
+    "chai": "^4.0.0",
     "eslint": "^5.4.0",
     "eslint-index": "^1.4.0",
     "eslint-plugin-shopify": "file:./.",

--- a/tests/fixtures/prettier/index.js
+++ b/tests/fixtures/prettier/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  foo: "bar",
+};

--- a/tests/fixtures/prettier/package.json
+++ b/tests/fixtures/prettier/package.json
@@ -1,0 +1,5 @@
+{
+  "eslintConfig": {
+    "extends": "plugin:shopify/prettier"
+  }
+}

--- a/tests/fixtures/typescript-prettier/index.ts
+++ b/tests/fixtures/typescript-prettier/index.ts
@@ -1,0 +1,1 @@
+export const foo: string = "bar";

--- a/tests/fixtures/typescript-prettier/package.json
+++ b/tests/fixtures/typescript-prettier/package.json
@@ -1,0 +1,5 @@
+{
+  "eslintConfig": {
+    "extends": "plugin:shopify/typescript-prettier"
+  }
+}

--- a/tests/lib/config/prettier.js
+++ b/tests/lib/config/prettier.js
@@ -1,0 +1,24 @@
+/* eslint-env node, mocha */
+/* eslint-disable flowtype/require-valid-file-annotation */
+import {expect} from 'chai';
+import {execSync} from 'child_process';
+
+// eslint-disable-next-line shopify/strict-component-boundaries
+import {fixtureFile} from '../../utilities';
+
+describe('config', () => {
+  describe('prettier', () => {
+    it('validates source files using prettier', () => {
+      expect(
+        () =>
+          execSync(
+            `node_modules/.bin/eslint --no-ignore ${fixtureFile('prettier')}`,
+          ),
+        // eslint-disable-next-line function-paren-newline
+      )
+        .throws()
+        .with.property('stdout')
+        .to.match(/Replace .*"bar".* with .*'bar'/);
+    }).timeout(8000);
+  });
+});

--- a/tests/lib/config/typescript-prettier.js
+++ b/tests/lib/config/typescript-prettier.js
@@ -1,0 +1,26 @@
+/* eslint-env node, mocha */
+/* eslint-disable flowtype/require-valid-file-annotation */
+import {expect} from 'chai';
+import {execSync} from 'child_process';
+
+// eslint-disable-next-line shopify/strict-component-boundaries
+import {fixtureFile} from '../../utilities';
+
+describe('config', () => {
+  describe('typescript-prettier', () => {
+    it('validates TypeScript source files using prettier', () => {
+      expect(
+        () =>
+          execSync(
+            `node_modules/.bin/eslint --ext .ts --no-ignore ${fixtureFile(
+              'typescript-prettier',
+            )}`,
+          ),
+        // eslint-disable-next-line function-paren-newline
+      )
+        .throws()
+        .with.property('stdout')
+        .to.match(/Replace .*"bar".* with .*'bar'/);
+    }).timeout(8000);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -269,6 +269,10 @@ assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
 
+assertion-error@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+
 ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
@@ -1086,6 +1090,17 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
+chai@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"
+  dependencies:
+    assertion-error "^1.0.1"
+    check-error "^1.0.1"
+    deep-eql "^3.0.0"
+    get-func-name "^2.0.0"
+    pathval "^1.0.0"
+    type-detect "^4.0.0"
+
 chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
@@ -1115,6 +1130,10 @@ chalk@~0.4.0:
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
+
+check-error@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
 
 chokidar@^1.6.1:
   version "1.7.0"
@@ -1305,6 +1324,12 @@ debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+deep-eql@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-3.0.1.tgz#dfc9404400ad1c8fe023e7da1df1c147c4b444df"
+  dependencies:
+    type-detect "^4.0.0"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -1622,7 +1647,7 @@ eslint-plugin-react@7.11.1:
     prop-types "^15.6.2"
 
 "eslint-plugin-shopify@file:./.":
-  version "24.0.0"
+  version "24.2.0"
   dependencies:
     babel-eslint "9.0.0"
     eslint-config-prettier "3.0.1"
@@ -1643,7 +1668,6 @@ eslint-plugin-react@7.11.1:
     eslint-plugin-react "7.11.1"
     eslint-plugin-sort-class-members "1.3.1"
     eslint-plugin-typescript "0.12.0"
-    graphql "^0.13.0"
     merge "1.2.0"
     pascal-case "^2.0.1"
     pkg-dir "2.0.0"
@@ -2055,6 +2079,10 @@ gauge@~2.7.3:
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
+
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
 
 get-stdin@^6.0.0:
   version "6.0.0"
@@ -3088,6 +3116,10 @@ path-type@^2.0.0:
   dependencies:
     pify "^2.0.0"
 
+pathval@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
+
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -3773,6 +3805,10 @@ type-check@~0.3.2:
   resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
   dependencies:
     prelude-ls "~1.1.2"
+
+type-detect@^4.0.0:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
 
 typedarray@^0.0.6:
   version "0.0.6"


### PR DESCRIPTION
When the `plugin:shopify/prettier` config is included in the eslint configuration, prettier linting is not active unless the configuration also include `'prettier/prettier': 'error'`. This PR adds the bare minimum config to enable prettier linting without overriding local file configuration.

resolves #169 
relates to #118 and #121 

### 🎩 Notes

There are new tests (in `tests/lib/config/prettier.js` and `tests/lib/config/typescript-prettier.js`) that confirm we can extend `plugin:shopify/prettier` and `plugin:shopify/typescript-prettier` respectively and validate that prettier rules are enforced on linted source files.