### PR TITLE
restoring prettier parser override in the typescript-prettier config

### DIFF
--- a/lib/config/typescript-prettier.js
+++ b/lib/config/typescript-prettier.js
@@ -4,5 +4,16 @@ module.exports = {
   rules: {
     // rules to disable to prefer prettier
     'typescript/member-delimiter-style': 'off',
+
+    // we must override the parser here otherwise prettier will automatically
+    // detect the parser based on file name and parse the file as graphql after
+    // eslint has already preprocessed the graphql into javascript syntax.
+    // see: https://github.com/prettier/eslint-plugin-prettier/issues/81
+    'prettier/prettier': [
+      'error',
+      {
+        parser: 'typescript',
+      },
+    ],
   },
 };


### PR DESCRIPTION
Fixes issue with `prettier` plugin using the incorrect parser when the `graphql` plugin is also enabled.