### PR TITLE
Adds `no-export-all` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 * `shopify/no-ancestor-directory-import` ([#149](https://github.com/Shopify/eslint-plugin-shopify/pull/149))
+* `shopify/no-export-all` ([#174](https://github.com/Shopify/eslint-plugin-shopify/pull/174))
 
 ## [26.0.0] - 2018-10-26
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ This plugin provides the following custom rules, which are included as appropria
 - [prefer-class-properties](docs/rules/prefer-class-properties.md): Prefer class properties to assignment of literals in constructors.
 - [prefer-early-return](docs/rules/prefer-early-return.md): Prefer early returns over full-body conditional wrapping in function declarations.
 - [no-ancestor-directory-import](docs/rules/no-ancestor-directory-import.md): Prefer imports from within a directory extend to the file from where they are importing without relying on an index file.
+- [no-export-all](docs/rules/no-export-all.md): Disallow exporting everything from a module using the wildcard asterisk (*) character.
 - [prefer-module-scope-constants](docs/rules/prefer-module-scope-constants.md): Prefer that screaming snake case variables always be defined using `const`, and always appear at module scope.
 - [prefer-twine](docs/rules/prefer-twine.md): Prefer Twine over Bindings as the name for twine imports.
 - [react-initialize-state](docs/rules/react-initialize-state.md): Require that React component state be initialized when it has a non-empty type.

--- a/docs/rules/no-export-all.md
+++ b/docs/rules/no-export-all.md
@@ -1,0 +1,23 @@
+# Disallow exporting everything from a module using the wildcard asterisk (*) character. (no-export-all)
+
+Using the wildcard asterisk (*) in an export statement will re-export everything from a module. Though concise, this syntax is far less clear than explicitly exporting the parts of module intended for use elsewhere in the application.
+
+## Rule Details
+
+This rule disallows using the wildcard asterisk syntax in export statements.
+
+Examples of **incorrect** code for this rule:
+
+```js
+export * from './someModule';
+```
+
+Examples of **correct** code for this rule:
+
+```js
+export {thing1, thing2} from 'someModule'
+```
+
+## When Not To Use It
+
+If you do not wish to prevent the wildcard asterisk syntax in export statements, you can safely disable this rule.

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
     'jsx-no-hardcoded-content': require('./lib/rules/jsx-no-hardcoded-content'),
     'jsx-prefer-fragment-wrappers': require('./lib/rules/jsx-prefer-fragment-wrappers'),
     'no-ancestor-directory-import': require('./lib/rules/no-ancestor-directory-import'),
+    'no-export-all': require('./lib/rules/no-export-all'),
     'no-debugger': require('./lib/rules/no-debugger'),
     'no-useless-computed-properties': require('./lib/rules/no-useless-computed-properties'),
     'no-fully-static-classes': require('./lib/rules/no-fully-static-classes'),

--- a/lib/config/rules/shopify.js
+++ b/lib/config/rules/shopify.js
@@ -15,8 +15,10 @@ module.exports = {
   'shopify/jsx-no-hardcoded-content': 'off',
   // Disallow useless wrapping elements in favour of fragment shorthand in JSX.
   'shopify/jsx-prefer-fragment-wrappers': 'off',
+  // Disallow exporting everything from a module using the wildcard asterisk (*) character.
+  'shopify/no-export-all': 'error',
   // Prefer that imports from within a directory extend to the file from where they are importing without relying on an index file.
-  'shopify/no-ancestor-directory-import': 'off',
+  'shopify/no-ancestor-directory-import': 'error',
   // Disallow the use of debugger (without fixer to prevent autofix on save in editors)
   'shopify/no-debugger': 'error',
   // Prevent the usage of unnecessary computed properties.

--- a/lib/rules/no-export-all.js
+++ b/lib/rules/no-export-all.js
@@ -1,0 +1,24 @@
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Disallow exporting everything from a module using the asterisk (*) character.',
+      category: 'Possible Errors',
+      url:
+        'https://github.com/Shopify/eslint-plugin-shopify/blob/master/docs/rules/no-export-all.md',
+      recommended: true,
+    },
+  },
+
+  create(context) {
+    return {
+      ExportAllDeclaration(node) {
+        context.report({
+          node,
+          message:
+            'Do not use the asterisk (*) to export everything from a module.',
+        });
+      },
+    };
+  },
+};

--- a/tests/lib/rules/no-export-all.js
+++ b/tests/lib/rules/no-export-all.js
@@ -1,0 +1,53 @@
+const {RuleTester} = require('eslint');
+const rule = require('../../../lib/rules/no-export-all');
+
+const ruleTester = new RuleTester();
+require('babel-eslint');
+
+const parser = 'babel-eslint';
+const errors = [
+  {
+    type: 'ExportAllDeclaration',
+    message: 'Do not use the asterisk (*) to export everything from a module.',
+  },
+];
+
+ruleTester.run('no-export-all', rule, {
+  valid: [
+    {
+      code: `export something from './something';`,
+      parser,
+    },
+    {
+      code: `export {something} from './something';`,
+      parser,
+    },
+    {
+      code: `export {something as somethingElse} from './something';`,
+      parser,
+    },
+    {
+      code: `export {default as somethingElse} from './something';`,
+      parser,
+    },
+    {
+      code: `export {
+          default as something,
+          somethingElse as anotherSomething,
+          anotherSomething as anotherSomethingElse,
+        } from './something';`,
+      parser,
+    },
+    {
+      code: `export {something, somethingElse, anotherSomething} from './something';`,
+      parser,
+    },
+  ],
+  invalid: [
+    {
+      code: `export * from './something';`,
+      parser,
+      errors,
+    },
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1909,7 +1909,7 @@ eslint-plugin-react@7.11.1:
     prop-types "^15.6.2"
 
 "eslint-plugin-shopify@file:./.":
-  version "25.1.0"
+  version "26.0.0"
   dependencies:
     babel-eslint "9.0.0"
     eslint-config-prettier "3.0.1"


### PR DESCRIPTION
First of a few rules that I will add that deal with consistent exporting.

Looking for general approval here (name, error message, etc...). Will follow up with the docs, configs, etc... once I receive confirmation this is a rule we actually want.

Things to review so far.
- Name (`no-export-all`)
- [Approach](https://github.com/Shopify/eslint-plugin-shopify/pull/174/files#diff-70e4aed6d9965b52c7315c1f79c1d253R16)
- [Tests](https://github.com/Shopify/eslint-plugin-shopify/pull/174/files#diff-c7f5fb7a1786a4286d89460b03b725d9R48)

@GoodForOneFare why did the `yarn.lock` appear in the diff?

### Update

Added everything ^, this is ready for a real review now.