### PR TITLE
adds `consistent-export-style` rule

### DIFF
--- a/lib/rules/consistent-export-style.js
+++ b/lib/rules/consistent-export-style.js
@@ -1,0 +1,106 @@
+import {sep, basename, extname} from 'path';
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Enforces consistency in how components are exported',
+      category: 'Best Practises',
+      recommended: true,
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const componentExportDecalations = [];
+
+    function isComponentsIndexFile() {
+      const pathParts = context.getFilename().split(sep);
+      const isIndexFile =
+        basename(
+          pathParts[pathParts.length - 1],
+          extname(pathParts[pathParts.length - 1]),
+        ) === 'index';
+
+      const inComponentsFolder =
+        pathParts[pathParts.length - 2] === 'components';
+
+      return isIndexFile && inComponentsFolder;
+    }
+
+    return {
+      'Program:exit': function() {
+        const exportsMap = groupExports(componentExportDecalations);
+        exportsMap.forEach((item) => {
+          if (item.nodes.length <= 1) {
+            if (checkSpecifierShape(item.nodes[0])) {
+              return;
+            }
+
+            context.report({
+              node: item.nodes[0],
+              message: [
+                'Export does not match a valid format.',
+                'Expecting a default component export',
+                'matching the name of the source,',
+                `followed by the component's Props.`,
+              ].join(' '),
+            });
+
+            return;
+          }
+
+          item.nodes.forEach((groupNode) =>
+            context.report({
+              node: groupNode,
+              message:
+                'Group multiple export from the same file into a single export.',
+            }),
+          );
+        });
+      },
+      ExportNamedDeclaration(node) {
+        if (isComponentsIndexFile()) {
+          componentExportDecalations.push(node);
+        }
+      },
+    };
+  },
+};
+
+function checkSpecifierShape(node) {
+  return validFirstSpecifier(node) && validSecondSpecifier(node);
+}
+
+function validFirstSpecifier(node) {
+  return (
+    node.specifiers[0].local.name === 'default' &&
+    node.specifiers[0].exported.name === getSourceName(node)
+  );
+}
+
+function validSecondSpecifier(node) {
+  return (
+    node.specifiers[1].local.name === 'Props' &&
+    node.specifiers[1].exported.name === `${getSourceName(node)}Props`
+  );
+}
+
+function getSourceName(node) {
+  const sourceParts = node.source.value.split('/');
+  return sourceParts[sourceParts.length - 1];
+}
+
+function groupExports(nodes) {
+  const cache = new Map();
+  nodes.forEach((node) => {
+    if (cache.has(node.source.value)) {
+      const currentNodes = cache.get(node.source.value).nodes;
+      cache.set(node.source.value, {nodes: [...currentNodes, node]});
+      return;
+    }
+
+    cache.set(node.source.value, {nodes: [node]});
+  });
+
+  return cache;
+}

--- a/tests/lib/rules/consistent-export-style.js
+++ b/tests/lib/rules/consistent-export-style.js
@@ -1,0 +1,63 @@
+const {RuleTester} = require('eslint');
+const rule = require('../../../lib/rules/consistent-export-style');
+const {fixtureFile} = require('../../utilities');
+
+const ruleTester = new RuleTester();
+
+require('babel-eslint');
+
+const parser = 'babel-eslint';
+
+const invalidShapeError = {
+  message: [
+    'Export does not match a valid format.',
+    'Expecting a default component export',
+    'matching the name of the source,',
+    `followed by the component's Props.`,
+  ].join(' '),
+  type: 'ExportNamedDeclaration',
+};
+
+const invalidGroupError = {
+  message: 'Group multiple export from the same file into a single export.',
+  type: 'ExportNamedDeclaration',
+};
+
+ruleTester.run('consistent-export-style', rule, {
+  valid: [
+    {
+      code: `
+        export {
+          default as Component,
+          Props as ComponentProps,
+          SomeRandomThing,
+        } from './Component';
+    `,
+      parser,
+      filename: fixtureFile('basic-app/app/components/index.js'),
+    },
+  ],
+  invalid: [
+    {
+      code: `
+        export {
+          default as Button,
+          Props as ButtonProps,
+        } from './NotAButton';
+    `,
+      parser,
+      errors: [invalidShapeError],
+      filename: fixtureFile('basic-app/app/components/index.js'),
+    },
+    {
+      code: `
+        export {default as Component} from './Component';
+        export {Props as ComponentProps} from './Component';
+        export {AnythingElse} from './Component';
+    `,
+      parser,
+      errors: [invalidGroupError, invalidGroupError, invalidGroupError],
+      filename: fixtureFile('basic-app/app/components/index.js'),
+    },
+  ],
+});


### PR DESCRIPTION
Closes part of: https://github.com/Shopify/web-foundation/issues/130

This is a first pass at enforcing a consistent export style in `components/index` files. At this point, I am looking for feedback on the general approach as this rule is not entirely straightforward.

According to this rule, the following code would be invalid because there are multiple exports from the same source.

```ts
export {default as BulkDiscountCode} from './BulkDiscountCode';
export {Props as BulkDiscountCodeProps} from './BulkDiscountCode';
export {DiscountCodesAppDescriptor} from './BulkDiscountCode';
```
The following would be invalid because shape of the specifiers does not match our ideal shape:
```ts
export {
  default as Button,
  Props as ButtonProps,
} from './NotAButton';
```

The ideal shape would be as follows:

```ts
export {
  default as Button,
  Props as ButtonProps,
  SomeRandomThing, // this part doesn't matter
} from './Button';
```

**Question**
* Should we add logic to enforce a strict syntax for exports in `compoentName/index`, or should that be a separate rule. It would be pretty easy to combine them here, but then we might want to provide a config for enabling one or the other individually.