### PR TITLE
Enable allowWholeFile for eslint-comments/disable-enable-pair

### DIFF
--- a/lib/config/rules/eslint-comments.js
+++ b/lib/config/rules/eslint-comments.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   // Require a eslint-enable comment for every eslint-disable comment
-  'eslint-comments/disable-enable-pair': 'error',
+  'eslint-comments/disable-enable-pair': ['error', {allowWholeFile: true}],
   // Disallow a eslint-enable comment for multiple eslint-disable comments
   'eslint-comments/no-aggregating-enable': 'error',
   // Disallow duplicate eslint-disable comments


### PR DESCRIPTION
This allows an eslint-disable directive without a matching close when it
appears before all code in the file. This allows you to disable rules
for a whole file, such as disabling no-console in scripts.

Fixes #183