### PR TITLE
Except arrow functions from declaration rule

### DIFF
--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -32,7 +32,7 @@ module.exports = {
   // Don't require function expressions to have a name
   'func-names': 'off',
   // Enforces use of function declarations or expressions
-  'func-style': ['error', 'declaration'],
+  'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
   // enforce consistent line breaks inside function parentheses
   'function-paren-newline': ['error', 'consistent'],
   // Blacklist certain identifiers to prevent them being used


### PR DESCRIPTION
Currently, this is frowned upon by the ESLint

```typescript
const MyComponent: React.SFC<Props> = ({foo}) => (<div>{foo}</div>);
```

However, this syntax offers nice semantics in terms of typing `Props`, as well as ensuring the return type is as expected.

The alternative, which ESLint expects (since we aren't using `this`, and there is therefore "no reason" to use an Arrow Function) is

```typescript
function MyComponent({foo}: Props) {
  return (<div>{foo}</div>);
}
```

With this notation,
- the `Props` type must be next to the parameter destructuring, potentially crowding things
- props from `IntrinsicAttributes` must be explicitly added to the `Props` interface
- a separate type must be used for the return value (if we want to validate the return type, which `React.SFC` gives us for free)
	- it is also not immediately obvious what that type should be (`React.Element`? `ReactNode`? something else?)

**This change whitelists arrow functions, such that they can be used as described above.**