### PR TITLE
Use a stricter import order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Changed
 
 * Updated `plugin:shopify/prettier`, `plugin:shopify/react`, and `plugin:shopify/typescript` to use `overrides` ([#173](https://github.com/Shopify/eslint-plugin-shopify/pull/173))
+* Update `import/order` rule to enforce ordering of internal, parent and sibling imports ([#189](https://github.com/Shopify/eslint-plugin-shopify/pull/189))
 
 ## [25.1.0] - 2018-10-01
 

--- a/lib/config/rules/import.js
+++ b/lib/config/rules/import.js
@@ -90,7 +90,7 @@ module.exports = {
   'import/order': [
     'error',
     {
-      groups: [['builtin', 'external'], ['internal', 'parent', 'sibling']],
+      groups: ['builtin', 'external', 'internal', 'parent', 'sibling'],
     },
   ],
   // Enforce a newline after import statements


### PR DESCRIPTION
A while ago we talked about [ordering imports in #web-foundation-tech](https://shopify.slack.com/archives/CCNRSKLTH/p1538573438000100).

General opinion was alphabetic ordering is annoying but grouping types of imports - node buildins, vs npm modules vs relative paths etc - would be handy as we already aim to do that anyway. 

This updates our import/order rule to be a bit stricter around forcing ordering based upon the type of import to the order goes internal imports (`components/Blah`) then parents (`../Blah`) then siblings (`./Blah`) instead of allowing those to be intermingled.

No ordering inside those groups is enforced, which shall keep the "no alphabets" group happy. And yes this has an autofix.

 See https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md for more info


