### PR TITLE
downgrading to eslint-plugin-graphql 2.1.0-0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 * Updated `plugin:shopify/prettier`, `plugin:shopify/react`, and `plugin:shopify/typescript` to use `overrides` ([#173](https://github.com/Shopify/eslint-plugin-shopify/pull/173))
 * Update `import/order` rule to enforce ordering of internal, parent and sibling imports ([#189](https://github.com/Shopify/eslint-plugin-shopify/pull/189))
 
+### Fixed
+
+* Rolling back `eslint-plugin-graphql` to `2.1.0-0` for multiple schema support ([#195](https://github.com/Shopify/eslint-plugin-shopify/pull/195))
+
 ## [25.1.0] - 2018-10-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-plugin-chai-expect": "1.1.1",
     "eslint-plugin-eslint-comments": "3.0.1",
     "eslint-plugin-flowtype": "2.41.0",
-    "eslint-plugin-graphql": "2.1.1",
+    "eslint-plugin-graphql": "2.1.0-0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jest": "21.22.0",
     "eslint-plugin-jsx-a11y": "6.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,10 +1816,10 @@ eslint-plugin-flowtype@2.41.0:
   dependencies:
     lodash "^4.15.0"
 
-eslint-plugin-graphql@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-2.1.1.tgz#dae5d597080075320ea8e98795056309ffe73a18"
-  integrity sha512-JT2paUyu3e9ZDnroSshwUMc6pKcnkfXTsZInX1+/rPotvqOLVLtdrx/cmfb7PTJwjiEAshwcpm3/XPdTpsKJPw==
+eslint-plugin-graphql@2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-graphql/-/eslint-plugin-graphql-2.1.0-0.tgz#49eb0126f4aef142ecb0b444baece5d481388361"
+  integrity sha512-BSLC0/LpCW+LEFnCWaM7UQ5sBJzxO1WtsS+8nmtErkFULvF76yVzVW8LdJ6ZRKE8W/gakJIh21VlaXjhUuqyqQ==
   dependencies:
     graphql-config "^2.0.1"
     lodash "^4.11.1"
@@ -1919,7 +1919,7 @@ eslint-plugin-react@7.11.1:
     eslint-plugin-chai-expect "1.1.1"
     eslint-plugin-eslint-comments "3.0.1"
     eslint-plugin-flowtype "2.41.0"
-    eslint-plugin-graphql "2.1.1"
+    eslint-plugin-graphql "2.1.0-0"
     eslint-plugin-import "2.14.0"
     eslint-plugin-jest "21.22.0"
     eslint-plugin-jsx-a11y "6.1.1"


### PR DESCRIPTION
The current version of `eslint-plugin-graphql` (`2.1.1`) [does not properly support multiple schemas](https://github.com/apollographql/eslint-plugin-graphql/pull/178) due to the schema caching mechanism. This is a rollback to `2.1.0-0` before the caching was introduced. This can be upgraded again once [caching is updated](https://github.com/apollographql/eslint-plugin-graphql/pull/179) to support multiple schemas.

blocked on #196 