### PR TITLE
fixing import-order lint error

### DIFF
--- a/lib/rules/strict-component-boundaries.js
+++ b/lib/rules/strict-component-boundaries.js
@@ -1,5 +1,5 @@
-const pascalCase = require('pascal-case');
 const {basename, extname, relative} = require('path');
+const pascalCase = require('pascal-case');
 const resolve = require('eslint-module-utils/resolve').default;
 
 module.exports = {


### PR DESCRIPTION
changing import order to satisfy `import-order` rule