### PR TITLE
Set up import parsers so import/* rules work in typescript

### DIFF
--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -12,6 +12,15 @@ module.exports = {
     sourceType: 'module',
   },
 
+  settings: {
+    'import/parsers': {
+      'typescript-eslint-parser': ['.ts', '.tsx'],
+    },
+    'import/resolver': {
+      typescript: {},
+    },
+  },
+
   overrides: [
     {
       files: ['*.ts', '*.tsx'],

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
   "dependencies": {
     "babel-eslint": "9.0.0",
     "eslint-config-prettier": "3.0.1",
+    "eslint-import-resolver-typescript": "^1.1.1",
     "eslint-module-utils": "2.1.1",
     "eslint-plugin-ava": "5.1.0",
     "eslint-plugin-babel": "5.1.0",

--- a/tests/fixtures/typescript-imports/.eslintrc.js
+++ b/tests/fixtures/typescript-imports/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extends: ['../../../lib/config/node.js', '../../../lib/config/typescript.js'],
+};

--- a/tests/fixtures/typescript-imports/check-cycle/File1.ts
+++ b/tests/fixtures/typescript-imports/check-cycle/File1.ts
@@ -1,0 +1,2 @@
+const result = 17;
+export default result;

--- a/tests/fixtures/typescript-imports/check-cycle/File2Circular.ts
+++ b/tests/fixtures/typescript-imports/check-cycle/File2Circular.ts
@@ -1,0 +1,4 @@
+import {File1} from './index';
+
+const result = File1 + 33;
+export default result;

--- a/tests/fixtures/typescript-imports/check-cycle/File3NoCircular.ts
+++ b/tests/fixtures/typescript-imports/check-cycle/File3NoCircular.ts
@@ -1,0 +1,4 @@
+import File1 from './File1';
+
+const result = File1 + 33;
+export default result;

--- a/tests/fixtures/typescript-imports/check-cycle/index.ts
+++ b/tests/fixtures/typescript-imports/check-cycle/index.ts
@@ -1,0 +1,3 @@
+export {default as File1} from './File1';
+export {default as File2Circular} from './File2Circular';
+export {default as File3NoCircular} from './File3NoCircular';

--- a/tests/fixtures/typescript-imports/check-path-segment/File1.ts
+++ b/tests/fixtures/typescript-imports/check-path-segment/File1.ts
@@ -1,0 +1,2 @@
+const value = 42;
+export {value};

--- a/tests/fixtures/typescript-imports/check-path-segment/File2.ts
+++ b/tests/fixtures/typescript-imports/check-path-segment/File2.ts
@@ -1,0 +1,4 @@
+import {value} from '../check-path-segment/File1';
+
+const result = value + 58;
+export default result;

--- a/tests/lib/config/typescript.js
+++ b/tests/lib/config/typescript.js
@@ -15,5 +15,25 @@ describe('config', () => {
         ),
       ).to.eq('');
     }).timeout(8000);
+
+    it('identifies import path issues', () => {
+      const esLintOutput = execESLint(
+        `--ext .ts --config ${fixtureFile(
+          'typescript-imports/.eslintrc.js',
+        )} ${fixtureFile('typescript-imports')}`,
+      );
+
+      expect(esLintOutput).to.contain('2 problems (2 errors, 0 warnings)');
+
+      // import/no-cycle error
+      expect(esLintOutput).to.contain(
+        `typescript-imports/check-cycle/index.ts\n  2:1  error  Dependency cycle detected`,
+      );
+
+      // import/no-useless-path-segments error
+      expect(esLintOutput).to.contain(
+        `typescript-imports/check-path-segment/File2.ts\n  1:21  error  Useless path segments for "../check-path-segment/File1", should be "./File1"`,
+      );
+    }).timeout(8000);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -90,6 +90,11 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -1529,6 +1534,13 @@ debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -1557,6 +1569,11 @@ deep-strict-equal@^0.2.0:
   integrity sha1-SgeBR6irV/ag1PVUckPNIvROtOQ=
   dependencies:
     core-assert "^0.2.0"
+
+deepmerge@^2.0.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 define-properties@^1.1.2:
   version "1.1.2"
@@ -1737,6 +1754,15 @@ eslint-import-resolver-node@^0.3.1:
   dependencies:
     debug "^2.6.8"
     resolve "^1.2.0"
+
+eslint-import-resolver-typescript@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-1.1.1.tgz#e6d42172b95144ef16610fe104ef38340edea591"
+  integrity sha512-jqSfumQ+H5y3FUJ6NjRkbOQSUOlbBucGTN3ELymOtcDBbPjVdm/luvJuCfCaIXGh8sEF26ma1qVdtDgl9ndhUg==
+  dependencies:
+    debug "^4.0.1"
+    resolve "^1.4.0"
+    tsconfig-paths "^3.6.0"
 
 eslint-index@^1.4.0:
   version "1.4.0"
@@ -3135,6 +3161,13 @@ json5@^0.5.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
 
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -3364,6 +3397,11 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 multimatch@^2.1.0:
   version "2.1.0"
@@ -4080,7 +4118,7 @@ resolve@^1.2.0:
   dependencies:
     path-parse "^1.0.5"
 
-resolve@^1.6.0, resolve@^1.8.1:
+resolve@^1.4.0, resolve@^1.6.0, resolve@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.8.1.tgz#82f1ec19a423ac1fbd080b0bab06ba36e84a7a26"
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
@@ -4470,6 +4508,17 @@ tryit@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.3.tgz#393be730a9446fd1ead6da59a014308f36c289cb"
   integrity sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=
+
+tsconfig-paths@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.6.0.tgz#f14078630d9d6e8b1dc690c1fc0cfb9cd0663891"
+  integrity sha512-mrqQIP2F4e03aMTCiPdedCIT300//+q0ET53o5WqqtQjmEICxP9yfz/sHTpPqXpssuJEzODsEzJaLRaf5J2X1g==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    deepmerge "^2.0.1"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
It turns out you need some extra config in order for some of the import
checking rules to do their thing with TypeScript.

To tophat:

* Check out a project that already uses eslint-plugin-shopify
* `yarn add --dev eslint-import-resolver-typescript`
* Add the settings to your eslint config.
* Run eslint. Marvel at all those new errors.