### PR TITLE
pinning typescript-eslint-parser at 20.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,6 @@
     "pascal-case": "^2.0.1",
     "pkg-dir": "2.0.0",
     "pluralize": "^7.0.0",
-    "typescript-eslint-parser": "^20.0.0"
+    "typescript-eslint-parser": "20.0.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1935,10 +1935,11 @@ eslint-plugin-react@7.11.1:
     prop-types "^15.6.2"
 
 "eslint-plugin-shopify@file:./.":
-  version "25.1.0"
+  version "26.1.0"
   dependencies:
     babel-eslint "9.0.0"
     eslint-config-prettier "3.0.1"
+    eslint-import-resolver-typescript "^1.1.1"
     eslint-module-utils "2.1.1"
     eslint-plugin-ava "5.1.0"
     eslint-plugin-babel "5.1.0"
@@ -1961,7 +1962,7 @@ eslint-plugin-react@7.11.1:
     pascal-case "^2.0.1"
     pkg-dir "2.0.0"
     pluralize "^7.0.0"
-    typescript-eslint-parser "^20.0.0"
+    typescript-eslint-parser "20.0.0"
 
 eslint-plugin-sort-class-members@1.3.1:
   version "1.3.1"
@@ -4549,7 +4550,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript-eslint-parser@^20.0.0:
+typescript-eslint-parser@20.0.0:
   version "20.0.0"
   resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-20.0.0.tgz#508678796bbcf60365ada28c38bd557e736bec01"
   integrity sha512-HZEoGA+LnS3etUlVAPX6I8sZ7872Yb0vPvQv6QDCIE44KD3bFmvPEQ4LbiD+qGkcxh6segjVK0v3rxpb2R6oSA==


### PR DESCRIPTION
due to an issue in `typescript-eslint-parser@20.1.0` (https://github.com/eslint/typescript-eslint-parser/issues/535) we must pin at `20.0.0` to prevent consumers from pulling this version in.