### PR TITLE
no-vague-titles no longer flags when call is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- ## Unreleased -->
 
+### Fixed
+
+* `jest/no-vague-titles` no longer flags when the word `call` is used.
+
 ## [26.1.1] - 2018-10-31
 
 ### Fixed

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -104,6 +104,6 @@ function getDescription({arguments: args}) {
 }
 
 function containsVagueWord(description) {
-  const vagueTerms = [/correct/i, /appropriate/i, /( )*all(\.|\s)/i];
+  const vagueTerms = [/correct/i, /appropriate/i, /(^|\s)+all(\.|\s)/i];
   return vagueTerms.find((term) => description.match(term));
 }

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -104,6 +104,6 @@ function getDescription({arguments: args}) {
 }
 
 function containsVagueWord(description) {
-  const vagueTerms = [/correct/i, /appropriate/i, /(^|\s)+all(\.|\s)/i];
+  const vagueTerms = [/correct/i, /appropriate/i, /\ball\b/i];
   return vagueTerms.find((term) => description.match(term));
 }

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -44,6 +44,10 @@ ruleTester.run('no-vague-titles', rule, {
       parser,
     },
     {
+      code: `describe('closing foo does not call bar')`,
+      parser,
+    },
+    {
       code: `xdescribe('foo bar baz')`,
       parser,
     },


### PR DESCRIPTION
The `jest/no-vague-titles` rule flagged the following test name as invalid:

`closing the modal does not call empty when emptyOnClose is false`

I've adjusted the regex to cater for when `all` is part of a word 👍 