### PR TITLE
adds `no-all-mocks-methods` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,7 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 ### Added
 
 * `shopify/no-ancestor-directory-import` ([#149](https://github.com/Shopify/eslint-plugin-shopify/pull/149))
+* `shopify/no-all-mocks-methods` ([#204](https://github.com/Shopify/eslint-plugin-shopify/pull/204))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+- `shopify/no-all-mocks-methods` ([#204](https://github.com/Shopify/eslint-plugin-shopify/pull/204))
 - `jest/valid-title`
 - `jest/prefer-hooks-on-top`
 - `jest/require-top-level-describe`
+
+## [32.0.0] - 2019-11-05
+
+- Enforce new-lines between groups import groups ([#409](https://github.com/Shopify/eslint-plugin-shopify/pull/409))
 
 ## [31.0.0] - 2019-10-23
 
@@ -283,7 +288,6 @@ Refer to the [Rules of Hooks documentation](https://reactjs.org/docs/hooks-rules
 ### Added
 
 * `shopify/no-ancestor-directory-import` ([#149](https://github.com/Shopify/eslint-plugin-shopify/pull/149))
-* `shopify/no-all-mocks-methods` ([#204](https://github.com/Shopify/eslint-plugin-shopify/pull/204))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ This plugin provides the following custom rules, which are included as appropria
 - [prefer-class-properties](docs/rules/prefer-class-properties.md): Prefer class properties to assignment of literals in constructors.
 - [prefer-early-return](docs/rules/prefer-early-return.md): Prefer early returns over full-body conditional wrapping in function declarations.
 - [no-ancestor-directory-import](docs/rules/no-ancestor-directory-import.md): Prefer imports from within a directory extend to the file from where they are importing without relying on an index file.
+- [no-all-mocks-methods](docs/rules/no-all-mocks-methods.md): Disallows jest allMocks methods.
 - [prefer-module-scope-constants](docs/rules/prefer-module-scope-constants.md): Prefer that screaming snake case variables always be defined using `const`, and always appear at module scope.
 - [prefer-twine](docs/rules/prefer-twine.md): Prefer Twine over Bindings as the name for twine imports.
 - [react-hooks-strict-return](docs/rules/react-hooks-strict-return.md): Restrict the number of returned items from React hooks.

--- a/docs/rules/jest/no-all-mocks-methods.md
+++ b/docs/rules/jest/no-all-mocks-methods.md
@@ -1,0 +1,35 @@
+# Disallows jest allMocks methods.
+
+This rule discourages the use of overly broad Jest methods such as `resetAllMocks`, `clearAllMocks`, `restoreAllMocks` and `resetModules`.
+
+## Rule Details
+
+These methods are discouraged because there should be explicit connections to the contents of your test file. Mocks should be reset/cleared/restored individually based on the purpose of your test suite.
+
+The following patterns are considered warnings:
+
+```js
+jest.resetAllMocks();
+```
+
+```js
+jest.clearAllMocks();
+```
+
+```js
+jest.restoreAllMocks();
+```
+
+```js
+jest.resetModules();
+```
+
+The following patterns are not warnings:
+
+```js
+jest.mock();
+```
+
+## Further Reading
+
+- [Shopify Jest Best Practices](https://github.com/Shopify/web-foundation/blob/master/Best%20practices/Jest.md#best-practices)

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
     'binary-assignment-parens': require('./lib/rules/binary-assignment-parens'),
     'class-property-semi': require('./lib/rules/class-property-semi'),
     'images-no-direct-imports': require('./lib/rules/images-no-direct-imports'),
+    'jest/no-all-mocks-methods': require('./lib/rules/jest/no-all-mocks-methods'),
     'jest/no-snapshots': require('./lib/rules/jest/no-snapshots'),
     'jest/no-vague-titles': require('./lib/rules/jest/no-vague-titles'),
     'jsx-no-complex-expressions': require('./lib/rules/jsx-no-complex-expressions'),

--- a/lib/config/rules/shopify.js
+++ b/lib/config/rules/shopify.js
@@ -5,6 +5,8 @@ module.exports = {
   'shopify/class-property-semi': 'error',
   // Prevent images from being directly imported
   'shopify/images-no-direct-imports': 'error',
+  // Disallow jest allMocks methods.
+  'shopify/jest/no-all-mocks-methods': 'off',
   // Disallow jest snapshots.
   'shopify/jest/no-snapshots': 'off',
   // Disallow vague words in test statements.

--- a/lib/rules/jest/no-all-mocks-methods.js
+++ b/lib/rules/jest/no-all-mocks-methods.js
@@ -1,0 +1,35 @@
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallows jest allMocks methods.',
+      category: 'Best Practices',
+      recommended: false,
+      uri:
+        'https://github.com/Shopify/eslint-plugin-shopify/blob/master/docs/rules/jest/no-all-mocks-methods.md',
+    },
+  },
+
+  create(context) {
+    return {
+      Identifier(node) {
+        if (isInvalidMocks(node.name)) {
+          context.report({
+            node,
+            message:
+              'Do not use {{method}} or related methods that are not explicit to your test. Instead, target individual mocks.',
+            data: {method: node.name},
+          });
+        }
+      },
+    };
+  },
+};
+
+function isInvalidMocks(name) {
+  return [
+    'resetAllMocks',
+    'clearAllMocks',
+    'restoreAllMocks',
+    'resetModules',
+  ].some((method) => method === name);
+}

--- a/lib/rules/jest/no-all-mocks-methods.js
+++ b/lib/rules/jest/no-all-mocks-methods.js
@@ -8,6 +8,10 @@ module.exports = {
         'https://github.com/Shopify/eslint-plugin-shopify/blob/master/docs/rules/jest/no-all-mocks-methods.md',
     },
   },
+  messages: {
+    allMocksMethod:
+      'Do not use {{method}} or related methods that are not explicit to a single mock. Instead, clear, reset and restore mocks individually.',
+  },
 
   create(context) {
     return {
@@ -15,8 +19,7 @@ module.exports = {
         if (isInvalidMocks(node.name)) {
           context.report({
             node,
-            message:
-              'Do not use {{method}} or related methods that are not explicit to a single mock. Instead, clear, reset and restore mocks individually.',
+            messageId: 'allMocksMethod',
             data: {method: node.name},
           });
         }

--- a/lib/rules/jest/no-all-mocks-methods.js
+++ b/lib/rules/jest/no-all-mocks-methods.js
@@ -16,7 +16,7 @@ module.exports = {
           context.report({
             node,
             message:
-              'Do not use {{method}} or related methods that are not explicit to your test. Instead, target individual mocks.',
+              'Do not use {{method}} or related methods that are not explicit to a single mock. Instead, clear, reset and restore mocks individually.',
             data: {method: node.name},
           });
         }

--- a/tests/lib/rules/jest/no-all-mocks-methods.js
+++ b/tests/lib/rules/jest/no-all-mocks-methods.js
@@ -1,0 +1,41 @@
+const {RuleTester} = require('eslint');
+const rule = require('../../../../lib/rules/jest/no-all-mocks-methods');
+
+const ruleTester = new RuleTester();
+function errorWithMethodName(name) {
+  return [
+    {
+      type: 'Identifier',
+      message: `Do not use ${name} or related methods that are not explicit to your test. Instead, target individual mocks.`,
+    },
+  ];
+}
+
+ruleTester.run('no-all-mocks-methods', rule, {
+  valid: [
+    {
+      code: `jest.mock()`,
+    },
+    {
+      code: `jest.fn()`,
+    },
+  ],
+  invalid: [
+    {
+      code: 'jest.resetAllMocks()',
+      errors: errorWithMethodName('resetAllMocks'),
+    },
+    {
+      code: 'jest.clearAllMocks()',
+      errors: errorWithMethodName('clearAllMocks'),
+    },
+    {
+      code: 'jest.restoreAllMocks()',
+      errors: errorWithMethodName('restoreAllMocks'),
+    },
+    {
+      code: 'jest.resetModules()',
+      errors: errorWithMethodName('resetModules'),
+    },
+  ],
+});

--- a/tests/lib/rules/jest/no-all-mocks-methods.js
+++ b/tests/lib/rules/jest/no-all-mocks-methods.js
@@ -1,15 +1,8 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../../lib/rules/jest/no-all-mocks-methods');
 
 const ruleTester = new RuleTester();
-function errorWithMethodName(name) {
-  return [
-    {
-      type: 'Identifier',
-      message: `Do not use ${name} or related methods that are not explicit to your test. Instead, target individual mocks.`,
-    },
-  ];
-}
 
 ruleTester.run('no-all-mocks-methods', rule, {
   valid: [
@@ -23,19 +16,35 @@ ruleTester.run('no-all-mocks-methods', rule, {
   invalid: [
     {
       code: 'jest.resetAllMocks()',
-      errors: errorWithMethodName('resetAllMocks'),
+      errors: [
+        {
+          messageId: 'allMocksMethod',
+        },
+      ],
     },
     {
       code: 'jest.clearAllMocks()',
-      errors: errorWithMethodName('clearAllMocks'),
+      errors: [
+        {
+          messageId: 'allMocksMethod',
+        },
+      ],
     },
     {
       code: 'jest.restoreAllMocks()',
-      errors: errorWithMethodName('restoreAllMocks'),
+      errors: [
+        {
+          messageId: 'allMocksMethod',
+        },
+      ],
     },
     {
       code: 'jest.resetModules()',
-      errors: errorWithMethodName('resetModules'),
+      errors: [
+        {
+          messageId: 'allMocksMethod',
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
Closes part of https://github.com/Shopify/eslint-plugin-shopify/issues/181
For more information see: https://github.com/Shopify/web-foundation/blob/master/Best%20practices/Jest.md#best-practices

Do not use `jest.resetAllMocks()`, `jest.clearAllMocks()`, `jest.restoreAllMocks()`, and `jest.resetModules()`.


> Why? These methods are overly broad and do not have explicit connections to the contents of your test file. Instead, reset/ clear/ restore individual mocks that are set up explicitly for the purposes of your test suite.

First time adding a rule, feedback welcomed 🙏 


cc @djirdehh 