### PR TITLE
enhancements to `no-vague-titles` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * `jest/no-vague-titles` no longer flags when the word `call` is used.
 
+### Changed
+* `jest/no-vague-titles` added `should` and `properly` to vague rules and new configuration to `allow` words.
+
 ## [26.1.1] - 2018-10-31
 
 ### Fixed

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -1,3 +1,22 @@
+const VAGUE_TERMS = {
+  should: /should/i,
+  correct: /correct/i,
+  appropriate: /appropriate/i,
+  all: /\ball\b/i,
+  properly: /properly/i,
+};
+
+const TEST_FUNCTION_NAMES = [
+  'it',
+  'xit',
+  'fit',
+  'test',
+  'xtest',
+  'describe',
+  'fdescribe',
+  'xdescribe',
+];
+
 module.exports = {
   meta: {
     docs: {
@@ -7,9 +26,27 @@ module.exports = {
       uri:
         'https://github.com/Shopify/eslint-plugin-shopify/blob/master/docs/rules/no-vague-titles.md',
     },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignore: {
+            type: 'array',
+            items: {enum: TEST_FUNCTION_NAMES},
+          },
+          allow: {
+            type: 'array',
+            items: {enum: Object.keys(VAGUE_TERMS)},
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
   create(context) {
-    const ignored = (context.options[0] && context.options[0].ignore) || [];
+    const options = context.options[0] || {};
+    const ignored = options.ignore || [];
+    const allowed = options.allow || [];
 
     function isIgnoredFunctionName(node) {
       const method = getMethodName(node);
@@ -27,7 +64,7 @@ module.exports = {
 
       const description = getDescription(node);
 
-      if (containsVagueWord(description)) {
+      if (containsVagueWord(description, allowed)) {
         const method = getMethodName(node);
 
         context.report({
@@ -54,16 +91,7 @@ function notTestFunction(node) {
 }
 
 function matchTestFunctionName(functionName) {
-  return (
-    functionName === 'it' ||
-    functionName === 'xit' ||
-    functionName === 'fit' ||
-    functionName === 'test' ||
-    functionName === 'xtest' ||
-    functionName === 'describe' ||
-    functionName === 'fdescribe' ||
-    functionName === 'xdescribe'
-  );
+  return TEST_FUNCTION_NAMES.includes(functionName);
 }
 
 function hasEmptyDescription({arguments: args}) {
@@ -103,7 +131,9 @@ function getDescription({arguments: args}) {
   return firstArgument && firstArgument.value;
 }
 
-function containsVagueWord(description) {
-  const vagueTerms = [/correct/i, /appropriate/i, /\ball\b/i];
-  return vagueTerms.find((term) => description.match(term));
+function containsVagueWord(description, allowed) {
+  return Object.entries(VAGUE_TERMS).find(
+    ([word, regex]) =>
+      allowed.includes(word) ? false : description.match(regex),
+  );
 }

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -150,6 +150,56 @@ ruleTester.run('no-vague-titles', rule, {
   ],
   invalid: [
     {
+      code: "it('properly')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "describe('properly')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "test('properly')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "fit('properly')",
+      parser,
+      errors: errorWithMethod('fit'),
+    },
+    {
+      code: "xdescribe('properly')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
+      code: "it('should')",
+      parser,
+      errors: errorWithMethod('it'),
+    },
+    {
+      code: "describe('should')",
+      parser,
+      errors: errorWithMethod('describe'),
+    },
+    {
+      code: "test('should')",
+      parser,
+      errors: errorWithMethod('test'),
+    },
+    {
+      code: "fit('should')",
+      parser,
+      errors: errorWithMethod('fit'),
+    },
+    {
+      code: "xdescribe('should')",
+      parser,
+      errors: errorWithMethod('xdescribe'),
+    },
+    {
       code: "it('correct')",
       parser,
       errors: errorWithMethod('it'),
@@ -750,4 +800,94 @@ ruleTester.run('no-vague-titles with ignore=it', rule, {
     },
   ],
   invalid: [],
+});
+
+ruleTester.run('no-vague-titles with allow=correct', rule, {
+  valid: [
+    {
+      code: "it('correct')",
+      options: [{allow: ['correct']}],
+    },
+    {
+      code: "it('appropriate all should correct properly')",
+      options: [
+        {allow: ['appropriate', 'should', 'all', 'correct', 'properly']},
+      ],
+    },
+  ],
+  invalid: [
+    {
+      code: "it('properly all correct')",
+      options: [{allow: ['correct']}],
+      errors: errorWithMethod('it'),
+    },
+  ],
+});
+
+ruleTester.run('no-vague-titles with allow=should', rule, {
+  valid: [
+    {
+      code: "it('should')",
+      options: [{allow: ['should']}],
+    },
+  ],
+  invalid: [
+    {
+      code: "it('properly all should')",
+      options: [{allow: ['should']}],
+      errors: errorWithMethod('it'),
+    },
+  ],
+});
+
+ruleTester.run('no-vague-titles with allow=all', rule, {
+  valid: [
+    {
+      code: "it('all')",
+      options: [{allow: ['all']}],
+    },
+  ],
+  invalid: [
+    {
+      code: "it('properly all should')",
+      options: [{allow: ['all']}],
+      errors: errorWithMethod('it'),
+    },
+  ],
+});
+
+ruleTester.run('no-vague-titles with allow=should', rule, {
+  valid: [
+    {
+      code: "it('should')",
+      options: [{allow: ['should']}],
+    },
+  ],
+  invalid: [
+    {
+      code: "it('properly all should')",
+      options: [{allow: ['should']}],
+      errors: errorWithMethod('it'),
+    },
+  ],
+});
+
+ruleTester.run('no-vague-titles with allow=appropriate', rule, {
+  valid: [
+    {
+      code: "it('appropriate')",
+      options: [{allow: ['appropriate']}],
+    },
+    {
+      code: "it('appropriate all should')",
+      options: [{allow: ['appropriate', 'should', 'all']}],
+    },
+  ],
+  invalid: [
+    {
+      code: "it('properly all should')",
+      options: [{allow: ['appropriate', 'should']}],
+      errors: errorWithMethod('it'),
+    },
+  ],
 });


### PR DESCRIPTION
This PR enhances the `no-vague-titles` rule in the following ways.
- Adds `should` and `properly` to the list of words considered vague.
- Adds new configuration to whitelist/allow words defined in this rule.
- Adds a schema for the configuration options.

closes https://github.com/Shopify/eslint-plugin-shopify/issues/199