### PR TITLE
Update changelog for arrow function func-style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,8 @@
 ### Changed
 
 * Updated `plugin:shopify/prettier`, `plugin:shopify/react`, and `plugin:shopify/typescript` to use `overrides` ([#173](https://github.com/Shopify/eslint-plugin-shopify/pull/173))
-* Update `import/order` rule to enforce ordering of internal, parent and sibling imports ([#189](https://github.com/Shopify/eslint-plugin-shopify/pull/189))
+* Updated `import/order` rule to enforce ordering of internal, parent and sibling imports ([#189](https://github.com/Shopify/eslint-plugin-shopify/pull/189))
+* Updated `func-style` rule to allow arrow functions ([#188](https://github.com/Shopify/eslint-plugin-shopify/pull/188))
 
 ### Fixed
 


### PR DESCRIPTION
This historically updates the changelog to include the added arrow function exemption to the `func-style` rule, [as requested](https://github.com/Shopify/eslint-plugin-shopify/pull/188#issuecomment-438366250).