### PR TITLE
Bump eslint-plugin-prettier to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 ### Fixed
 
 * `jest/no-vague-titles` no longer flags when the word `call` is used.
+* Update `eslint-plugin-prettier` to 3.0.1 so it does not crash when given an unparsable file ([#212](https://github.com/Shopify/eslint-plugin-shopify/pull/212))
 
 ### Changed
+
 * `jest/no-vague-titles` added `should` and `properly` to vague rules and new configuration to `allow` words.
 
 ## [26.1.1] - 2018-10-31

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "eslint-plugin-lodash": "2.6.1",
     "eslint-plugin-mocha": "5.2.0",
     "eslint-plugin-node": "7.0.1",
-    "eslint-plugin-prettier": "3.0.0",
+    "eslint-plugin-prettier": "3.0.1",
     "eslint-plugin-promise": "4.0.0",
     "eslint-plugin-react": "7.11.1",
     "eslint-plugin-sort-class-members": "1.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,10 +1916,10 @@ eslint-plugin-node@7.0.1:
     resolve "^1.8.1"
     semver "^5.5.0"
 
-eslint-plugin-prettier@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.0.tgz#f6b823e065f8c36529918cdb766d7a0e975ec30c"
-  integrity sha512-4g11opzhqq/8+AMmo5Vc2Gn7z9alZ4JqrbZ+D4i8KlSyxeQhZHlmIrY8U9Akf514MoEhogPa87Jgkq87aZ2Ohw==
+eslint-plugin-prettier@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.0.1.tgz#19d521e3981f69dd6d14f64aec8c6a6ac6eb0b0d"
+  integrity sha512-/PMttrarPAY78PLvV3xfWibMOdMDl57hmlQ2XqFeA37wd+CJ7WSxV7txqjVPHi/AAFKd2lX0ZqfsOc/i5yFCSQ==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
@@ -1943,6 +1943,7 @@ eslint-plugin-react@7.11.1:
   version "26.1.1"
   dependencies:
     babel-eslint "9.0.0"
+    common-tags "^1.8.0"
     eslint-config-prettier "3.0.1"
     eslint-import-resolver-typescript "^1.1.1"
     eslint-module-utils "2.1.1"
@@ -1958,7 +1959,7 @@ eslint-plugin-react@7.11.1:
     eslint-plugin-lodash "2.6.1"
     eslint-plugin-mocha "5.2.0"
     eslint-plugin-node "7.0.1"
-    eslint-plugin-prettier "3.0.0"
+    eslint-plugin-prettier "3.0.1"
     eslint-plugin-promise "4.0.0"
     eslint-plugin-react "7.11.1"
     eslint-plugin-sort-class-members "1.3.1"


### PR DESCRIPTION
This [fixes a bug](https://github.com/prettier/eslint-plugin-prettier/pull/141) where eslint would crash if given an unparsable file.