### PR TITLE
Adds "every" and "descriptive" to no-vague-titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 <!-- ## Unreleased -->
 
+* `jest/no-vague-titles` added `every` and `descriptive` as vague words. ([#221](https://github.com/Shopify/eslint-plugin-shopify/pull/221))
+
 ## [26.2.0] - 2019-02-14
 
 ### Added

--- a/docs/rules/jest/no-vague-titles.md
+++ b/docs/rules/jest/no-vague-titles.md
@@ -6,6 +6,10 @@ The following vague terms are flagged:
 * "correct"
 * "appropriate"
 * "all"
+* "properly"
+* "should"
+* "every"
+* "descriptive"
 
 ## Rule Details
 
@@ -29,6 +33,23 @@ it('is called with the Foo and Bar plugins')
 test('renders the user avatar and email')
 describe('receives the date and publishState props from the router params')
 ```
+
+### `allow`
+
+```json
+{
+  "jest/no-vague-titles": [
+    "error",
+    {
+      "allow": ["properly", "correct"]
+    }
+  ]
+}
+```
+
+This array option allows a subset of vague words so that this rule does not report their usage as being incorrect.
+
+By default, none of these options are enabled (the equivalent of `{ "allow": [] }`).
 
 ### `ignore`
 

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -7,6 +7,8 @@ const VAGUE_TERMS = {
   appropriate: /appropriate/i,
   all: /\ball\b/i,
   properly: /properly/i,
+  every: /every/i,
+  descriptive: /descriptive/i,
 };
 
 const TEST_FUNCTION_NAMES = [

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -241,6 +241,96 @@ ruleTester.run('no-vague-titles', rule, {
       ],
     },
     {
+      code: "it('descriptive')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "describe('descriptive')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "test('descriptive')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "fit('descriptive')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "xdescribe('descriptive')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "it('every')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "describe('every')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "test('every')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "fit('every')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "xdescribe('every')",
+      parser,
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
       code: "it('correct')",
       parser,
       errors: [
@@ -1308,6 +1398,54 @@ ruleTester.run('no-vague-titles with allow=appropriate', rule, {
     {
       code: "it('properly all should')",
       options: [{allow: ['appropriate', 'should']}],
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('no-vague-titles with allow=every', rule, {
+  valid: [
+    {
+      code: "it('every')",
+      options: [{allow: ['every']}],
+    },
+    {
+      code: "it('every all should')",
+      options: [{allow: ['every', 'should', 'all']}],
+    },
+  ],
+  invalid: [
+    {
+      code: "it('properly all should')",
+      options: [{allow: ['every', 'should']}],
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+  ],
+});
+
+ruleTester.run('no-vague-titles with allow=descriptive', rule, {
+  valid: [
+    {
+      code: "it('descriptive')",
+      options: [{allow: ['descriptive']}],
+    },
+    {
+      code: "it('descriptive all should')",
+      options: [{allow: ['descriptive', 'should', 'all']}],
+    },
+  ],
+  invalid: [
+    {
+      code: "it('properly all should')",
+      options: [{allow: ['descriptive', 'should']}],
       errors: [
         {
           messageId: 'containsVagueWord',


### PR DESCRIPTION
When enabling this rule in web it was easy to replace some of the vague words with these. `all` becomes `every`, and `descriptive` is just another filler word. Adding these words to the rule as per @ismail-syed's suggestion.

I also added the `allow` config option to the docs. Closing https://github.com/Shopify/eslint-plugin-shopify/issues/209

