### PR TITLE
Update merge dependency to v1.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-react": "7.12.4",
     "eslint-plugin-sort-class-members": "1.3.1",
     "eslint-plugin-typescript": "0.12.0",
-    "merge": "1.2.0",
+    "merge": "1.2.1",
     "pascal-case": "^2.0.1",
     "pkg-dir": "2.0.0",
     "pluralize": "^7.0.0",


### PR DESCRIPTION
There was an alert sent out for a security vulnerability to the `merge` package, suggested remediation is to upgrade to `merge` version 1.2.1 or later

> The merge.recursive function in the merge package <1.2.1 can be tricked into adding or modifying properties of the Object prototype. These properties will be present on all objects allowing for a denial of service attack.

See https://nvd.nist.gov/vuln/detail/CVE-2018-16469 for more details

There's no changelog for the `merge` package, but I believe fixing this vulnerability is the only change between `1.2.0` and `1.2.1`: https://github.com/yeikos/js.merge/pull/17/files