### PR TITLE
Remove `describe` from jest/no-if

### DIFF
--- a/lib/rules/jest/no-if.js
+++ b/lib/rules/jest/no-if.js
@@ -1,8 +1,7 @@
 const {docsUrl} = require('../../utilities');
-const {
-  TEST_FUNCTION_NAMES,
-  getTestMethodName,
-} = require('../../utilities/jest');
+const {getTestMethodName} = require('../../utilities/jest');
+
+const TEST_FUNCTION_NAMES = ['it', 'xit', 'fit', 'test', 'xtest'];
 
 module.exports = {
   meta: {

--- a/tests/lib/rules/jest/no-if.js
+++ b/tests/lib/rules/jest/no-if.js
@@ -20,6 +20,62 @@ ruleTester.run('no-if', rule, {
       })`,
       parser,
     },
+    {
+      code: `describe('foo', () => {
+        if('bar') {}
+      })`,
+      parser,
+    },
+    {
+      code: `describe.skip('foo', () => {
+        if('bar') {}
+      })`,
+      parser,
+    },
+    {
+      code: `describe('foo', () => {
+        if('bar') {}
+      })`,
+      parser,
+    },
+    {
+      code: `xdescribe('foo', () => {
+        if('bar') {}
+      })`,
+      parser,
+    },
+    {
+      code: `fdescribe('foo', () => {
+        if('bar') {}
+      })`,
+      parser,
+    },
+    {
+      code: `describe('foo', () => {
+        if('bar') {}
+      })
+      if('baz') {}
+      `,
+      parser,
+    },
+    {
+      code: `describe('foo', () => {
+          afterEach(() => {
+            if('bar') {}
+          });
+        })
+      `,
+      parser,
+    },
+    {
+      code: `describe('foo', () => {
+          beforeEach(() => {
+            if('bar') {}
+          });
+        })
+      `,
+      parser,
+    },
   ],
   invalid: [
     {
@@ -68,61 +124,6 @@ ruleTester.run('no-if', rule, {
     },
     {
       code: `fit('foo', () => {
-          if('bar') {}
-        })`,
-      parser,
-      errors: [
-        {
-          messageId: 'noIf',
-        },
-      ],
-    },
-    {
-      code: `describe('foo', () => {
-        if('bar') {}
-      })`,
-      parser,
-      errors: [
-        {
-          messageId: 'noIf',
-        },
-      ],
-    },
-    {
-      code: `describe.skip('foo', () => {
-        if('bar') {}
-      })`,
-      parser,
-      errors: [
-        {
-          messageId: 'noIf',
-        },
-      ],
-    },
-    {
-      code: `describe.only('foo', () => {
-        if('bar') {}
-      })`,
-      parser,
-      errors: [
-        {
-          messageId: 'noIf',
-        },
-      ],
-    },
-    {
-      code: `xdescribe.only('foo', () => {
-        if('bar') {}
-      })`,
-      parser,
-      errors: [
-        {
-          messageId: 'noIf',
-        },
-      ],
-    },
-    {
-      code: `fdescribe.only('foo', () => {
         if('bar') {}
       })`,
       parser,
@@ -207,19 +208,6 @@ ruleTester.run('no-if', rule, {
         {
           messageId: 'noIf',
         },
-        {
-          messageId: 'noIf',
-        },
-      ],
-    },
-    {
-      code: `describe('foo', () => {
-          if('bar') {}
-      })
-      if('baz') {}
-      `,
-      parser,
-      errors: [
         {
           messageId: 'noIf',
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,13 +1761,6 @@ eslint-plugin-jsx-a11y@6.2.1:
     has "^1.0.3"
     jsx-ast-utils "^2.0.1"
 
-eslint-plugin-lodash@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-lodash/-/eslint-plugin-lodash-5.1.0.tgz#f7dc6c14f104cacb169a18d17c27d9c015a53924"
-  integrity sha512-mMKmf1OMLS8VExtaHCcrwBmsYIiOVYEibnAFDzXrbJdtFGOcLEw37tryN/WGYKBiJy6nAIGC43i5Wh3KA9lO2g==
-  dependencies:
-    lodash "4.17.11"
-
 eslint-plugin-node@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-8.0.1.tgz#55ae3560022863d141fa7a11799532340a685964"
@@ -3030,7 +3023,7 @@ lodash.unescape@4.0.1:
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
 
-lodash@4.17.11, lodash@^4.11.1, lodash@^4.17.11, lodash@^4.3.0:
+lodash@^4.11.1, lodash@^4.17.11, lodash@^4.3.0:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==


### PR DESCRIPTION
This PR Removes `describe` from the checked function names of `jest/no-if`.

I tested this rule out in a few projects and if statements in afterEach/ beforeEach blocks and in general within `describe` blocks is a valid thing to do.