### PR TITLE
Remove consistent-return for React

### DIFF
--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -25,6 +25,7 @@ module.exports = {
       'shopify/jsx-no-complex-expressions': 'error',
       'shopify/jsx-no-hardcoded-content': 'error',
       'shopify/jsx-prefer-fragment-wrappers': 'error',
+      'consistent-return': 'off',
     },
   ),
 


### PR DESCRIPTION
This PR turns off `consistent-return` in the react config in order to allow the `useEffect` hook API of returning a cleanup function. 