### PR TITLE
Fix duplicate `camelcase` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- ## Unreleased -->
 
+### Removed
+
+* turned off `babel/camelcase` in typescript config because it overlaps with `@typescript-eslint/camelcase`. ([#238](https://github.com/Shopify/eslint-plugin-shopify/pull/238))
+
 ## [27.0.0] - 2019-04-08
 
 ### Added

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -33,6 +33,7 @@ module.exports = {
         // for ensuring proper `this` usage in functions not assigned to
         // object properties.
         'babel/no-invalid-this': 'off',
+        'babel/camelcase': 'off',
 
         // Handled by TypeScript itself
         'no-undef': 'off',


### PR DESCRIPTION
Currently, we are getting duplicate reports for camelcase variables.

To solve this in this PR I am keeping the `babel/camelcase` rule on unless they are using the typescript config, at which point we can use the `@typescript-eslint/camelcase` rule and turn off the babel rule.

<img width="1033" alt="Screen Shot 2019-04-09 at 10 08 30 AM" src="https://user-images.githubusercontent.com/462077/55807026-75953480-5aaf-11e9-8bf7-00ab2143c7be.png">
