### PR TITLE
Enable jsx-no-bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- ## Unreleased -->
 
+### Changed
+
+* `react/jsx-no-bind` now allows function and arrow functions. ([#239](https://github.com/Shopify/eslint-plugin-shopify/pull/239))
+
 ### Removed
 
 * turned off `babel/camelcase` in typescript config because it overlaps with `@typescript-eslint/camelcase`. ([#238](https://github.com/Shopify/eslint-plugin-shopify/pull/238))

--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -128,8 +128,9 @@ module.exports = {
   'react/jsx-max-depth': 'off',
   // Limit maximum of props on a single line in JSX
   'react/jsx-max-props-per-line': 'off',
-  // Prevent usage of .bind() and arrow functions in JSX props
-  'react/jsx-no-bind': 'error',
+  // Prevent usage of .bind() in JSX props
+  // Disabled to allow for React hook patterns
+  'react/jsx-no-bind': 'off',
   // Prevent comments from being inserted as text nodes
   'react/jsx-no-comment-textnodes': 'error',
   // Prevent duplicate props in JSX


### PR DESCRIPTION
This PR changes the config for `react/jsx-no-bind` to allow functions as part of https://github.com/Shopify/eslint-plugin-shopify/issues/231.