### PR TITLE
Disable `node/no-extraneous-require`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- ## Unreleased -->
 
+### Removed
+
+* turned off `node/no-extraneous-require` because it duplicates reported violations from `import/no-extraneous-dependencies` ([#240](https://github.com/Shopify/eslint-plugin-shopify/pull/240)
+
 ## [27.0.1] - 2019-04-10
 
 ### Changed

--- a/lib/config/rules/node.js
+++ b/lib/config/rules/node.js
@@ -27,7 +27,8 @@ module.exports = {
   // defer to import/no-extraneous-dependencies
   'node/no-extraneous-import': 'off',
   // Disallow require() expressions of extraneous packages
-  'node/no-extraneous-require': 'error',
+  // defer to import/no-extraneous-dependencies
+  'node/no-extraneous-require': 'off',
   // Enforce either module.exports or exports.
   'node/exports-style': ['error', 'module.exports'],
   // enforce either Buffer or require("buffer").Buffer


### PR DESCRIPTION
This rule is a duplicate of `import/no-extraneous-dependencies`, which looks at both `require`s and `import`s for extraneous dependencies.