### PR TITLE
Optimize images-no-direct-imports rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Fixed
 
 * `shopify/restrict-full-import` "empty" array pattern (eg: `const [, bar] = foo` errors ([#243](https://github.com/Shopify/eslint-plugin-shopify/pull/243))
+* Optimized `shopify/images/no-direct-imports` to be much faster in the common case ([#247](https://github.com/Shopify/eslint-plugin-shopify/pull/247))
 
 ### Added
 
-* updated `eslint-plugin-import` to version `22.4.1` which introduces the [`no-unused-modules`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unused-modules.md) rule. 
+* updated `eslint-plugin-import` to version `22.4.1` which introduces the [`no-unused-modules`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unused-modules.md) rule.
 * updated `eslint-plugin-jest` to version `22.4.1` which introduces the [`no-empty-title`](https://github.com/jest-community/eslint-plugin-jest/commit/c793b7a) rule.
 * `shopify/react-hooks-strict-return` Restrict the number of returned items from React hooks. ([#237](https://github.com/Shopify/eslint-plugin-shopify/pull/237))
 

--- a/lib/rules/images-no-direct-imports.js
+++ b/lib/rules/images-no-direct-imports.js
@@ -2,8 +2,8 @@ const {basename, dirname, extname} = require('path');
 const resolve = require('eslint-module-utils/resolve').default;
 const {docsUrl} = require('../utilities');
 
-function isImageImport(resolvedSource) {
-  return /\.(svg|png|jpg)$/.test(resolvedSource);
+function isImageImport(filename) {
+  return /\.(svg|png|jpg)$/.test(filename);
 }
 
 function isImportFromCurrentFolderIndex(contextFilename, resolvedSource) {
@@ -26,7 +26,11 @@ module.exports = {
   },
   create(context) {
     function checkNode(node) {
-      if (!node.source || !node.source.value) {
+      if (
+        !node.source ||
+        !node.source.value ||
+        !isImageImport(node.source.value)
+      ) {
         return;
       }
 
@@ -34,7 +38,6 @@ module.exports = {
 
       if (
         resolvedSource &&
-        isImageImport(resolvedSource) &&
         !isImportFromCurrentFolderIndex(context.getFilename(), resolvedSource)
       ) {
         context.report({


### PR DESCRIPTION
Check the extension of the import before trying to resolve it. This
allows us to escape early and not trigger trying to resolve the path
(which is expensive compared to string comparisons) if the import isn't
for an image.