### PR TITLE
Revert Typescript update to fix prettier

### DIFF
--- a/lib/config/rules/prettier-typescript.js
+++ b/lib/config/rules/prettier-typescript.js
@@ -1,5 +1,4 @@
 module.exports = {
   // don't use lint rules, defer to prettier rules instead
-  '@typescript-eslint/member-delimiter-style': 'off',
-  '@typescript-eslint/type-annotation-spacing': 'off',
+  'typescript/member-delimiter-style': 'off',
 };

--- a/lib/config/rules/typescript.js
+++ b/lib/config/rules/typescript.js
@@ -1,40 +1,57 @@
-// See https://github.com/typescript-eslint/typescript-eslint
+// See https://github.com/nzakas/eslint-plugin-typescript
 
 module.exports = {
   // Enforce one space after the colon and zero spaces before the colon of a type annotation.
-  '@typescript-eslint/type-annotation-spacing': ['error'],
+  'typescript/type-annotation-spacing': ['error'],
+
   // Require explicit return types on functions and class methods
-  '@typescript-eslint/explicit-function-return-type': 'off',
+  'typescript/explicit-function-return-type': 'off',
+
   // Enforce accessibility modifiers on class properties and methods. (member-access from TSLint)
-  '@typescript-eslint/explicit-member-accessibility': 'off',
+  'typescript/explicit-member-accessibility': 'off',
+
   // Enforce interface names are prefixed. (interface-name from TSLint)
-  '@typescript-eslint/interface-name-prefix': 'off',
+  'typescript/interface-name-prefix': 'off',
+
   // Enforce naming conventions for class members by visibility.
-  '@typescript-eslint/member-naming': 'off',
+  'typescript/member-naming': 'off',
+
   // Enforce /// <reference /> is not used. (no-reference from TSLint)
-  '@typescript-eslint/no-triple-slash-reference': 'error',
+  'typescript/no-triple-slash-reference': 'error',
+
   // Disallow generic Array constructors
-  '@typescript-eslint/no-array-constructor': 'error',
+  'typescript/no-array-constructor': 'error',
+
   // Enforce the use of as Type assertions instead of <Type> assertions. (no-angle-bracket-type-assertion from TSLint)
-  '@typescript-eslint/no-angle-bracket-type-assertion': 'error',
+  'typescript/no-angle-bracket-type-assertion': 'error',
+
   // Enforce the any type is not used. (no-any from TSLint)
-  '@typescript-eslint/no-explicit-any': 'off',
+  'typescript/no-explicit-any': 'off',
+
   // Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean. (no-inferrable-types from TSLint)
-  '@typescript-eslint/no-inferrable-types': ['error'],
+  'typescript/no-inferrable-types': ['error'],
+
   // Disallow the use of custom TypeScript modules and namespaces
-  '@typescript-eslint/no-namespace': 'error',
+  'typescript/no-namespace': 'off',
+
   // Disallow non-null assertions using the ! postfix operator
-  '@typescript-eslint/no-non-null-assertion': 'off',
+  'typescript/no-non-null-assertion': 'error',
+
   // Disallow the use of variables before they are defined.
-  '@typescript-eslint/no-use-before-define': 'off',
+  'typescript/no-use-before-define': 'off',
+
   // Disallows the use of require statements except in import statements (no-var-requires from TSLint)
-  '@typescript-eslint/no-var-requires': 'error',
+  'typescript/no-var-requires': 'error',
+
   // Enforce the use of the keyword namespace over module to declare custom TypeScript modules. (no-internal-module from TSLint)
-  '@typescript-eslint/prefer-namespace-keyword': 'off',
+  'typescript/prefer-namespace-keyword': 'off',
+
   // Disallow the use of type aliases. (interface-over-type-literal from TSLint)
-  '@typescript-eslint/no-type-alias': 'off',
+  // breaks `export type Message = string | ((colorizer: any) => string);`
+  'typescript/no-type-alias': 'off',
+
   // Enforce a standard member declaration order. (member-ordering from TSLint)
-  '@typescript-eslint/member-ordering': [
+  'typescript/member-ordering': [
     'error',
     {
       default: [
@@ -54,73 +71,63 @@ module.exports = {
       ],
     },
   ],
+
   // Prevent TypeScript-specific constructs from being erroneously flagged as unused
-  '@typescript-eslint/no-unused-vars': 'off',
+  'typescript/no-unused-vars': 'off',
+
   // Enforce member overloads to be consecutive.
-  '@typescript-eslint/adjacent-overload-signatures': 'error',
+  'typescript/adjacent-overload-signatures': 'error',
+
   // Disallow parameter properties in class constructors. (no-parameter-properties from TSLint)
-  '@typescript-eslint/no-parameter-properties': 'off',
+  'typescript/no-parameter-properties': 'off',
+
   // Enforce PascalCased class and interface names. (class-name from TSLint)
-  '@typescript-eslint/class-name-casing': 'error',
+  'typescript/class-name-casing': 'error',
+
   // Enforce a member delimiter style in interfaces and type literals.
-  '@typescript-eslint/member-delimiter-style': [
+  'typescript/member-delimiter-style': [
     'error',
     {
-      multiline: {
-        delimiter: 'semi',
-        requireLast: true,
-      },
-      singleline: {
-        delimiter: 'semi',
-        requireLast: true,
+      delimiter: 'semi',
+      overrides: {
+        typeLiteral: {
+          delimiter: 'semi',
+        },
       },
     },
   ],
+
   // Disallow the declaration of empty interfaces. (no-empty-interface from TSLint)
-  '@typescript-eslint/no-empty-interface': 'off',
-  // Requires using either T[] or Array<T> for arrays (array-type)
-  '@typescript-eslint/array-type': ['error', 'array'],
-  // Enforces that types will not to be used
-  '@typescript-eslint/ban-types': [
-    'error',
-    {
-      types: {
-        String: {message: 'Use string instead', fixWith: 'string'},
-        Boolean: {message: 'Use boolean instead', fixWith: 'boolean'},
-        Number: {message: 'Use number instead', fixWith: 'number'},
-        Object: {message: 'Use object instead', fixWith: 'object'},
-        Array: {message: 'Provide a more specific type'},
-      },
-    },
-  ],
-  // Enforce camelCase naming convention
-  '@typescript-eslint/camelcase': ['error', {properties: 'always'}],
-  // Enforces naming of generic type variables
-  '@typescript-eslint/generic-type-naming': 'off',
-  // Enforce consistent indentation
-  '@typescript-eslint/indent': 'off',
-  // Forbids the use of classes as namespaces
-  '@typescript-eslint/no-extraneous-class': 'error',
-  // Disallow iterating over an array with a for-in loop
-  '@typescript-eslint/no-for-in-array': 'error',
-  // Enforce valid definition of new and constructor
-  '@typescript-eslint/no-misused-new': 'error',
-  // Forbids an object literal to appear in a type assertion expression
-  '@typescript-eslint/no-object-literal-type-assertion': 'error',
-  // Disallows invocation of require()
-  '@typescript-eslint/no-require-imports': 'off',
-  // Disallow aliasing this
-  '@typescript-eslint/no-this-alias': ['error', {allowDestructuring: true}],
-  // Warns when a namespace qualifier is unnecessary
-  '@typescript-eslint/no-unnecessary-qualifier': 'error',
-  // Warns if a type assertion does not change the type of an expression
-  '@typescript-eslint/no-unnecessary-type-assertion': 'error',
-  // Disallow unnecessary constructors
-  '@typescript-eslint/no-useless-constructor': 'off',
-  // Use function types instead of interfaces with call signatures
-  '@typescript-eslint/prefer-function-type': 'off',
-  // Functions that return promises must be async
-  '@typescript-eslint/promise-function-async': 'off',
-  // When adding two variables, operands must both be of type number or of type string
-  '@typescript-eslint/restrict-plus-operands': 'error',
+  'typescript/no-empty-interface': 'off',
+
+  // Already supported by TS
+  'no-undef': 'off',
+  'no-unused-expressions': 'off',
+  'no-unused-vars': 'off',
+  'no-useless-constructor': 'off',
+  'no-shadow': 'off',
+  'no-use-before-define': 'off',
+  'sort-class-members/sort-class-members': 'off',
+
+  // Does not support TS equivalent
+  'import/no-unresolved': 'off',
+  'import/no-extraneous-dependencies': 'off',
+  'no-empty-function': 'off',
+
+  // Flag overloaded methods in TS
+  'no-dupe-class-members': 'off',
+
+  // Flag typedef files with multiple modules with export default
+  'import/export': 'off',
+
+  // Breaks typescript-eslint-parser
+  strict: 'off',
+  'shopify/prefer-early-return': 'off',
+  'array-callback-return': 'off',
+  'getter-return': 'off',
+
+  // Prefer TypeScript enums be defined using Pascal case
+  'shopify/typescript/prefer-pascal-case-enums': 'error',
+  // Prefer TypeScript enums be defined using singular names
+  'shopify/typescript/prefer-singular-enums': 'error',
 };

--- a/lib/config/typescript.js
+++ b/lib/config/typescript.js
@@ -3,17 +3,11 @@ const merge = require('merge');
 module.exports = {
   extends: 'plugin:shopify/esnext',
 
-  plugins: [
-    '@typescript-eslint',
-    'eslint-comments',
-    'sort-class-members',
-    'import',
-    'shopify',
-  ],
+  plugins: ['typescript'],
 
   settings: {
     'import/parsers': {
-      '@typescript-eslint/parser': ['.ts', '.tsx'],
+      'typescript-eslint-parser': ['.ts', '.tsx'],
     },
     'import/resolver': {
       typescript: {},
@@ -22,7 +16,7 @@ module.exports = {
 
   overrides: [
     {
-      parser: '@typescript-eslint/parser',
+      parser: 'typescript-eslint-parser',
       parserOptions: {
         ecmaVersion: 2017,
         sourceType: 'module',
@@ -33,41 +27,6 @@ module.exports = {
         // for ensuring proper `this` usage in functions not assigned to
         // object properties.
         'babel/no-invalid-this': 'off',
-        'babel/camelcase': 'off',
-
-        // Handled by TypeScript itself
-        'no-undef': 'off',
-        'no-unused-expressions': 'off',
-        'no-unused-vars': 'off',
-        'no-useless-constructor': 'off',
-        'no-shadow': 'off',
-        'no-use-before-define': 'off',
-
-        // Does not support TS equivalent
-        'import/no-unresolved': 'off',
-        'import/no-extraneous-dependencies': 'off',
-        'no-empty-function': 'off',
-
-        // Conflicts with @typescript-eslint rules
-        'sort-class-members/sort-class-members': 'off',
-        camelcase: 'off',
-
-        // Flag overloaded methods in TS
-        'no-dupe-class-members': 'off',
-
-        // Flag typedef files with multiple modules with export default
-        'import/export': 'off',
-
-        // Breaks @typescript-eslint/parser
-        strict: 'off',
-        'shopify/prefer-early-return': 'off',
-        'array-callback-return': 'off',
-        'getter-return': 'off',
-
-        // Prefer TypeScript enums be defined using Pascal case
-        'shopify/typescript/prefer-pascal-case-enums': 'error',
-        // Prefer TypeScript enums be defined using singular names
-        'shopify/typescript/prefer-singular-enums': 'error',
       }),
     },
   ],

--- a/lib/rules/react-initialize-state.js
+++ b/lib/rules/react-initialize-state.js
@@ -23,7 +23,7 @@ module.exports = {
         }
 
         classInfo = {
-          hasStateType: !classHasEmptyStateType(node),
+          hasStateType: classHasNonEmptyStateType(node),
           declaredState: false,
         };
       },
@@ -70,25 +70,17 @@ module.exports = {
   }),
 };
 
-function classHasEmptyStateType({superTypeParameters}) {
-  const hasNoStateType =
-    !superTypeParameters ||
-    superTypeParameters.params.length < 2 ||
-    superTypeParameters.params[1].type === 'TSNeverKeyword' ||
-    superTypeParameters.params[1].type === 'TSAnyKeyword' ||
-    superTypeParameters.params[1].type === 'AnyTypeAnnotation';
-
-  if (hasNoStateType) {
-    return true;
-  }
-
-  if (superTypeParameters.params[1].type === 'ObjectTypeAnnotation') {
-    return superTypeParameters.params[1].properties.length === 0;
-  }
-
-  if (superTypeParameters.params[1].type === 'TSTypeLiteral') {
-    return superTypeParameters.params[1].members.length === 0;
-  }
-
-  return false;
+function classHasNonEmptyStateType({superTypeParameters}) {
+  return (
+    Boolean(superTypeParameters) &&
+    superTypeParameters.params.length > 1 &&
+    superTypeParameters.params[1].type !== 'TSNeverKeyword' &&
+    superTypeParameters.params[1].type !== 'TSAnyKeyword' &&
+    superTypeParameters.params[1].type !== 'AnyTypeAnnotation' &&
+    (superTypeParameters.params[1].typeName == null ||
+      superTypeParameters.params[1].typeName.members == null ||
+      superTypeParameters.params[1].typeName.members.length > 0) &&
+    (superTypeParameters.params[1].properties == null ||
+      superTypeParameters.params[1].properties.length > 0)
+  );
 }

--- a/package.json
+++ b/package.json
@@ -65,15 +65,13 @@
     "prettier": "^1.17.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "typescript": "^3.4.3"
+    "typescript": "~3.1.1"
   },
   "peerDependencies": {
     "eslint": "<6 >5.0.0",
     "prettier": "^1.14.0"
   },
   "dependencies": {
-    "eslint-plugin-typescript": "0.12.0",
-    "typescript-eslint-parser": "20.0.0",
     "babel-eslint": "10.0.1",
     "common-tags": "^1.8.0",
     "eslint-config-prettier": "4.1.0",
@@ -91,9 +89,11 @@
     "eslint-plugin-react": "7.12.4",
     "eslint-plugin-react-hooks": "^1.6.0",
     "eslint-plugin-sort-class-members": "1.4.0",
+    "eslint-plugin-typescript": "0.12.0",
     "merge": "1.2.1",
     "pascal-case": "^2.0.1",
     "pkg-dir": "4.1.0",
-    "pluralize": "^7.0.0"
+    "pluralize": "^7.0.0",
+    "typescript-eslint-parser": "20.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,8 +72,8 @@
     "prettier": "^1.14.0"
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^1.6.0",
-    "@typescript-eslint/parser": "^1.6.0",
+    "eslint-plugin-typescript": "0.12.0",
+    "typescript-eslint-parser": "20.0.0",
     "babel-eslint": "10.0.1",
     "common-tags": "^1.8.0",
     "eslint-config-prettier": "4.1.0",

--- a/tests/fixtures/typescript-imports/.eslintrc.js
+++ b/tests/fixtures/typescript-imports/.eslintrc.js
@@ -1,8 +1,8 @@
 module.exports = {
   plugins: ['self'],
   extends: ['plugin:self/typescript', 'plugin:self/node'],
-  parserOptions: {
-    project: 'tsconfig.json',
-    tsconfigRootDir: __dirname,
-  },
+  // parserOptions: {
+  //   project: 'tsconfig.json',
+  //   tsconfigRootDir: __dirname,
+  // },
 };

--- a/tests/fixtures/typescript-imports/.eslintrc.js
+++ b/tests/fixtures/typescript-imports/.eslintrc.js
@@ -1,8 +1,8 @@
 module.exports = {
   plugins: ['self'],
   extends: ['plugin:self/typescript', 'plugin:self/node'],
-  // parserOptions: {
-  //   project: 'tsconfig.json',
-  //   tsconfigRootDir: __dirname,
-  // },
+  parserOptions: {
+    project: 'tsconfig.json',
+    tsconfigRootDir: __dirname,
+  },
 };

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -4,9 +4,9 @@ const rule = require('../../../../lib/rules/jest/no-vague-titles');
 const ruleTester = new RuleTester();
 
 require('babel-eslint');
-require('@typescript-eslint/parser');
+require('typescript-eslint-parser');
 
-const typeScriptParser = '@typescript-eslint/parser';
+const typeScriptParser = 'typescript-eslint-parser';
 const parser = 'babel-eslint';
 
 ruleTester.run('no-vague-titles', rule, {

--- a/tests/lib/rules/react-initialize-state.js
+++ b/tests/lib/rules/react-initialize-state.js
@@ -4,10 +4,10 @@ const rule = require('../../../lib/rules/react-initialize-state');
 const ruleTester = new RuleTester();
 
 require('babel-eslint');
-require('@typescript-eslint/parser');
+require('typescript-eslint-parser');
 
 const babelParser = 'babel-eslint';
-const typeScriptParser = '@typescript-eslint/parser';
+const typeScriptParser = 'typescript-eslint-parser';
 
 const errors = [
   {

--- a/tests/lib/rules/react-prefer-private-members.js
+++ b/tests/lib/rules/react-prefer-private-members.js
@@ -4,10 +4,10 @@ const rule = require('../../../lib/rules/react-prefer-private-members');
 const ruleTester = new RuleTester();
 
 require('babel-eslint');
-require('@typescript-eslint/parser');
+require('typescript-eslint-parser');
 
 const babelParser = 'babel-eslint';
-const typeScriptParser = '@typescript-eslint/parser';
+const typeScriptParser = 'typescript-eslint-parser';
 
 function makeError({type = 'ClassProperty', memberName, componentName}) {
   return {

--- a/tests/lib/rules/react-type-state.js
+++ b/tests/lib/rules/react-type-state.js
@@ -3,9 +3,9 @@ const rule = require('../../../lib/rules/react-type-state');
 
 const ruleTester = new RuleTester();
 
-require('@typescript-eslint/parser');
+require('typescript-eslint-parser');
 
-const parser = '@typescript-eslint/parser';
+const parser = 'typescript-eslint-parser';
 
 const errors = [
   {

--- a/tests/lib/rules/typescript/prefer-pascal-case-enums.js
+++ b/tests/lib/rules/typescript/prefer-pascal-case-enums.js
@@ -4,9 +4,9 @@ const rule = require('../../../../lib/rules/typescript/prefer-pascal-case-enums'
 
 const ruleTester = new RuleTester();
 
-require('@typescript-eslint/parser');
+require('typescript-eslint-parser');
 
-const typeScriptParser = '@typescript-eslint/parser';
+const typeScriptParser = 'typescript-eslint-parser';
 
 function errorWithName(name) {
   return {

--- a/tests/lib/rules/typescript/prefer-singular-enums.js
+++ b/tests/lib/rules/typescript/prefer-singular-enums.js
@@ -4,9 +4,9 @@ const rule = require('../../../../lib/rules/typescript/prefer-singular-enums');
 
 const ruleTester = new RuleTester();
 
-require('@typescript-eslint/parser');
+require('typescript-eslint-parser');
 
-const typeScriptParser = '@typescript-eslint/parser';
+const typeScriptParser = 'typescript-eslint-parser';
 
 function errorWithName(name) {
   return {

--- a/tests/lib/rules/webpack/no-unnamed-dynamic-imports.js
+++ b/tests/lib/rules/webpack/no-unnamed-dynamic-imports.js
@@ -56,7 +56,7 @@ const validExamples = [
       ).then(bar => bar);
     }
     `,
-    parser: '@typescript-eslint/parser',
+    parser: 'typescript-eslint-parser',
   },
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,7 +9,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.4.3":
+"@babel/core@^7.1.6", "@babel/core@^7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.4.3.tgz#198d6d3af4567be3989550d97e068de94503074f"
   integrity sha512-oDpASqKFlbspQfzAE7yaeTmdljSH2ADIvBlb0RwbStltTuWa0+7CCI1fYVINNv9saHPa1W7oaKeuNuKj+RQCvA==
@@ -823,33 +823,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
-
-"@typescript-eslint/eslint-plugin@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-1.6.0.tgz#a5ff3128c692393fb16efa403ec7c8a5593dab0f"
-  integrity sha512-U224c29E2lo861TQZs6GSmyC0OYeRNg6bE9UVIiFBxN2MlA0nq2dCrgIVyyRbC05UOcrgf2Wk/CF2gGOPQKUSQ==
-  dependencies:
-    "@typescript-eslint/parser" "1.6.0"
-    "@typescript-eslint/typescript-estree" "1.6.0"
-    requireindex "^1.2.0"
-    tsutils "^3.7.0"
-
-"@typescript-eslint/parser@1.6.0", "@typescript-eslint/parser@^1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-1.6.0.tgz#f01189c8b90848e3b8e45a6cdad27870529d1804"
-  integrity sha512-VB9xmSbfafI+/kI4gUK3PfrkGmrJQfh0N4EScT1gZXSZyUxpsBirPL99EWZg9MmPG0pzq/gMtgkk7/rAHj4aQw==
-  dependencies:
-    "@typescript-eslint/typescript-estree" "1.6.0"
-    eslint-scope "^4.0.0"
-    eslint-visitor-keys "^1.0.0"
-
-"@typescript-eslint/typescript-estree@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-1.6.0.tgz#6cf43a07fee08b8eb52e4513b428c8cdc9751ef0"
-  integrity sha512-A4CanUwfaG4oXobD5y7EXbsOHjCwn8tj1RDd820etpPAjH+Icjc2K9e/DQM1Hac5zH2BSy+u6bjvvF2wwREvYA==
-  dependencies:
-    lodash.unescape "4.0.1"
-    semver "5.5.0"
 
 abbrev@1:
   version "1.1.1"
@@ -1748,6 +1721,13 @@ eslint-plugin-sort-class-members@1.4.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-sort-class-members/-/eslint-plugin-sort-class-members-1.4.0.tgz#71295d127752131e798ed1e5e76970f2c2c3ae48"
   integrity sha512-FQG6d4Cy2vYmG9gr6J138E91WaltqwOk/b/7GCssPqnUmizrcgOeN91bV5eOTuoS4RSH1Jdn4ukWEtyWLwV8ig==
 
+eslint-plugin-typescript@0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-typescript/-/eslint-plugin-typescript-0.12.0.tgz#e23d58cb27fe28e89fc641a1f20e8d862cb99aef"
+  integrity sha512-2+DNE8nTvdNkhem/FBJXLPSeMDOZL68vHHNfTbM+PBc5iAuwBe8xLSQubwKxABqSZDwUHg+mwGmv5c2NlImi0Q==
+  dependencies:
+    requireindex "~1.1.0"
+
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
@@ -1774,14 +1754,6 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.0.tgz#50bf3071e9338bcdc43331794a0cb533f0136172"
-  integrity sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -1800,7 +1772,7 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^4.2.0:
+eslint@4.19.1, eslint@^4.2.0:
   version "4.19.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-4.19.1.tgz#32d1d653e1d90408854bfb296f076ec7e186a300"
   integrity sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==
@@ -3449,10 +3421,10 @@ require-uncached@^1.0.3:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requireindex@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
-  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha1-5UBLgVV+91225JxacgBIk/4D4WI=
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -3843,17 +3815,10 @@ tsconfig-paths@^3.6.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
-
-tsutils@^3.7.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.8.0.tgz#7a3dbadc88e465596440622b65c04edc8e187ae5"
-  integrity sha512-XQdPhgcoTbCD8baXC38PQ0vpTZ8T3YrE+vR66YIj/xvDt1//8iAhafpIT/4DmvzzC1QFapEImERu48Pa01dIUA==
-  dependencies:
-    tslib "^1.8.1"
 
 type-check@~0.3.2:
   version "0.3.2"
@@ -3871,6 +3836,22 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript-eslint-parser@20.0.0:
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-20.0.0.tgz#508678796bbcf60365ada28c38bd557e736bec01"
+  integrity sha512-HZEoGA+LnS3etUlVAPX6I8sZ7872Yb0vPvQv6QDCIE44KD3bFmvPEQ4LbiD+qGkcxh6segjVK0v3rxpb2R6oSA==
+  dependencies:
+    eslint "4.19.1"
+    typescript-estree "2.1.0"
+
+typescript-estree@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/typescript-estree/-/typescript-estree-2.1.0.tgz#b2f3353494409ed53bf7055b46f78c1fbbe47661"
+  integrity sha512-t4o+7pB4OnxV36Bp41Vgtq8vXIvIUbx1vM98PSE2mL5QBY6woFaBN9hhD8pZHIrAu24IB5gzxbkEJOXj4lWNXQ==
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.5.0"
 
 typescript@^3.4.3:
   version "3.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3853,10 +3853,10 @@ typescript-estree@2.1.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@^3.4.3:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.3.tgz#0eb320e4ace9b10eadf5bc6103286b0f8b7c224f"
-  integrity sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==
+typescript@~3.1.1:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.6.tgz#b6543a83cfc8c2befb3f4c8fba6896f5b0c9be68"
+  integrity sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
This PR reverts the typescript updates from https://github.com/Shopify/eslint-plugin-shopify/pull/233 because they break the vscode prettier plugin. Without these changes, vscode will not format code using prettier-eslint. The following error will display in the output:

```
Error while loading rule '@typescript-eslint/no-unnecessary-qualifier'/Users/mattseccafien/src/github.com/Shopify/graphql-tools-web/src/utilities.ts:: You have used a rule which requires parserServices to be generated. You must therefore provide a value for the "parserOptions.project" property for @typescript-eslint/parser.
Occurred while linting /Users/mattseccafien/src/github.com/Shopify/graphql-tools-web/src/utilities.ts
```


