### PR TITLE
Fix hook strict return on undefined returns

### DIFF
--- a/lib/rules/react-hooks-strict-return.js
+++ b/lib/rules/react-hooks-strict-return.js
@@ -72,9 +72,13 @@ module.exports = {
 };
 
 function exceedsMaxReturnProperties(node, scope, max) {
-  const {
-    argument: {type, elements},
-  } = node;
+  const {argument} = node;
+
+  if (argument === null) {
+    return false;
+  }
+
+  const {type, elements} = argument;
 
   if (type !== 'ArrayExpression') {
     return getProps(node, scope).length > max;

--- a/tests/lib/rules/react-hooks-strict-return.js
+++ b/tests/lib/rules/react-hooks-strict-return.js
@@ -145,6 +145,16 @@ ruleTester.run('react-hooks-strict-return', rule, {
       }`,
       parser,
     },
+    {
+      code: `function useHookWithNoReturn() {}`,
+      parser,
+    },
+    {
+      code: `function useHookUndefinedReturn() {
+        return;
+      }`,
+      parser,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Sometimes hooks return undefined. In these cases, the `argument` is null explicitly, and the hook is valid according to this rule. This PR adds an early return to accommodate this type of hook.