### PR TITLE
Add version: detect to React settings

### DIFF
--- a/lib/config/react.js
+++ b/lib/config/react.js
@@ -3,6 +3,12 @@ const merge = require('merge');
 module.exports = {
   extends: 'plugin:shopify/esnext',
 
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+
   env: {
     browser: true,
   },


### PR DESCRIPTION
From the eslint-plugin-react docs:

```
// React version. "detect" automatically picks the version you have installed.
// You can also use `16.0`, `16.3`, etc, if you want to override the detected value.
// default to latest and warns if missing
// It will default to "detect" in the future
```

Question: Should we bother adding this if it will eventually be the default?
