### PR TITLE
Enable checkAliases for react/no-unsafe rule

### DIFF
--- a/lib/config/rules/react.js
+++ b/lib/config/rules/react.js
@@ -64,7 +64,7 @@ module.exports = {
   // Prevent usage of unknown DOM property
   'react/no-unknown-property': 'off',
   // Prevent usage of UNSAFE_ methods
-  'react/no-unsafe': 'error',
+  'react/no-unsafe': ['error', {checkAliases: true}],
   // Prevent definitions of unused prop types
   'react/no-unused-prop-types': 'error',
   // Attempts to discover all state fields in a React component and warn if any of them are never read.


### PR DESCRIPTION
By default this rule raises errors on usage of
UNSAFE_componentWillMount, UNSAFE_componentWillReceiveProps and
UNSAFE_componentWillUpdate.

Enabling checkAliases will also raise an error on usage of their
unprefixed versions too (componentWillMount, componentWillReceiveProps,
componentWillUpdate).

See https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unsafe.md

(There was a brief period where these unprefixed versions triggerd the no-deprecated rule, but that was reverted as they're not actually deprecated just yet as per https://github.com/yannickcr/eslint-plugin-react/pull/2069 and https://github.com/yannickcr/eslint-plugin-react/pull/2075)