### PR TITLE
Enable import/no-namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   - `node/prefer-promises/dns` and `node/prefer-promises/fs` These rules disallow the callback API in favor of promise API for the dns and fs modules. ([257](https://github.com/Shopify/eslint-plugin-shopify/pull/257))
   - `jest/no-mocks-import` This rule disallows manually importing from `__mocks__` ([246](https://github.com/Shopify/eslint-plugin-shopify/pull/246))
   - `react/state-in-constructor` Enforce state initialization to be in a class property. ([256](https://github.com/Shopify/eslint-plugin-shopify/pull/246))
+  - `import/no-namespace` Prevents namespace imports. ([305](https://github.com/Shopify/eslint-plugin-shopify/pull/305))
 
 ### Fixed
 

--- a/lib/config/rules/import.js
+++ b/lib/config/rules/import.js
@@ -71,7 +71,7 @@ module.exports = {
   // Report repeated import of the same module in multiple places
   'import/no-duplicates': 'error',
   // Report namespace imports
-  'import/no-namespace': 'off',
+  'import/no-namespace': 'error',
   // Ensure consistent use of file extension within the import path
   'import/extensions': [
     'error',

--- a/lib/config/rules/typescript.js
+++ b/lib/config/rules/typescript.js
@@ -32,7 +32,7 @@ module.exports = {
   'typescript/no-inferrable-types': ['error'],
 
   // Disallow the use of custom TypeScript modules and namespaces
-  'typescript/no-namespace': 'off',
+  'typescript/no-namespace': 'error',
 
   // Disallow non-null assertions using the ! postfix operator
   'typescript/no-non-null-assertion': 'off',

--- a/tests/fixtures/typescript-no-js/index.ts
+++ b/tests/fixtures/typescript-no-js/index.ts
@@ -1,3 +1,3 @@
-import * as path from 'path';
+import path from 'path';
 
 export default path;


### PR DESCRIPTION
After going through the process of writing a [first-party, opinionated version of this rule](https://github.com/Shopify/eslint-plugin-shopify/pull/305), I have settled upon just using the third-party rule from `eslint-plugin-import` instead.
