### PR TITLE
Revert "Enable import/no-namespace"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
   - `node/prefer-promises/dns` and `node/prefer-promises/fs` These rules disallow the callback API in favor of promise API for the dns and fs modules. ([257](https://github.com/Shopify/eslint-plugin-shopify/pull/257))
   - `jest/no-mocks-import` This rule disallows manually importing from `__mocks__` ([246](https://github.com/Shopify/eslint-plugin-shopify/pull/246))
   - `react/state-in-constructor` Enforce state initialization to be in a class property. ([256](https://github.com/Shopify/eslint-plugin-shopify/pull/246))
-  - `import/no-namespace` Prevents namespace imports. ([305](https://github.com/Shopify/eslint-plugin-shopify/pull/305))
 
 ### Fixed
 

--- a/lib/config/rules/import.js
+++ b/lib/config/rules/import.js
@@ -71,7 +71,7 @@ module.exports = {
   // Report repeated import of the same module in multiple places
   'import/no-duplicates': 'error',
   // Report namespace imports
-  'import/no-namespace': 'error',
+  'import/no-namespace': 'off',
   // Ensure consistent use of file extension within the import path
   'import/extensions': [
     'error',

--- a/lib/config/rules/typescript.js
+++ b/lib/config/rules/typescript.js
@@ -32,7 +32,7 @@ module.exports = {
   'typescript/no-inferrable-types': ['error'],
 
   // Disallow the use of custom TypeScript modules and namespaces
-  'typescript/no-namespace': 'error',
+  'typescript/no-namespace': 'off',
 
   // Disallow non-null assertions using the ! postfix operator
   'typescript/no-non-null-assertion': 'off',

--- a/tests/fixtures/typescript-no-js/index.ts
+++ b/tests/fixtures/typescript-no-js/index.ts
@@ -1,3 +1,3 @@
-import path from 'path';
+import * as path from 'path';
 
 export default path;


### PR DESCRIPTION
Reverts Shopify/eslint-plugin-shopify#305

There are far too many violations of this rule and no way to configure it differently enough. Going to re-explore a custom version of this rule instead, after all.