### PR TITLE
Forbid `I` prefixes in interface names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-<!-- ## Unreleased -->
+## Unreleased
+
+### Changed
+
+- Enabled `typescript/interface-name-prefix` to prevent `I` prefixes in TypeScript interface names
 
 ## [29.0.2] - 2019-06-18
 

--- a/lib/config/rules/typescript.js
+++ b/lib/config/rules/typescript.js
@@ -11,7 +11,7 @@ module.exports = {
   'typescript/explicit-member-accessibility': 'off',
 
   // Enforce interface names are prefixed. (interface-name from TSLint)
-  'typescript/interface-name-prefix': 'off',
+  'typescript/interface-name-prefix': ['error', 'never'],
 
   // Enforce naming conventions for class members by visibility.
   'typescript/member-naming': 'off',


### PR DESCRIPTION
### Why tho?
This [TypeScript handbook](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#names) says not to (it also says that it's only a guideline for contribution to TypeScript itself so...) [this StackOverflow answer](https://stackoverflow.com/questions/31876947/confused-about-the-interface-and-class-coding-guidelines-for-typescript/41967120#41967120) is pretty convincing.

Testing this in an internal project shows a few hits, but it's a low amount of effort to manually fix them:

<img width="631" alt="web (zsh) 2019-06-20 16-49-22" src="https://user-images.githubusercontent.com/673655/59880674-a4ffd180-937b-11e9-8c8c-95c9f5d43af0.png">

