### PR TITLE
Support eslint v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- [Major] Updated to eslint v6, enabled `no-console` and enabled `no-async-promise-executor` ([330](https://github.com/Shopify/eslint-plugin-shopify/pull/330))
 - Enabled `typescript/interface-name-prefix` to prevent `I` prefixes in TypeScript interface names
 
 ## [29.0.2] - 2019-06-18

--- a/lib/config/rules/possible-errors.js
+++ b/lib/config/rules/possible-errors.js
@@ -6,26 +6,15 @@ module.exports = {
   // Enforce return statements in getters
   'getter-return': ['error', {allowImplicit: true}],
   // disallow using an async function as a Promise executor
-  'no-async-promise-executor': 'off',
+  'no-async-promise-executor': 'error',
   // Disallow await inside of loops
   'no-await-in-loop': 'off',
   // Disallow comparing against -0
   'no-compare-neg-zero': 'error',
-  // Disallow or enforce trailing commas
-  'comma-dangle': [
-    'error',
-    {
-      arrays: 'always-multiline',
-      objects: 'always-multiline',
-      imports: 'always-multiline',
-      exports: 'always-multiline',
-      functions: 'always-multiline',
-    },
-  ],
   // Disallow assignment in conditional expressions
   'no-cond-assign': 'error',
   // Disallow use of console
-  'no-console': 'error',
+  'no-console': 'off',
   // Disallow use of constant expressions in conditions
   'no-constant-condition': ['error', {checkLoops: false}],
   // Disallow control characters in regular expressions
@@ -63,7 +52,7 @@ module.exports = {
   // Disallow the use of object properties of the global object (Math and JSON) as functions
   'no-obj-calls': 'error',
   // Disallow use of Object.prototypes builtins directly
-  'no-prototype-builtins': 'off',
+  'no-prototype-builtins': 'error',
   // Disallow multiple spaces in a regular expression literal
   'no-regex-spaces': 'error',
   // Disallow sparse arrays

--- a/lib/config/rules/stylistic-issues.js
+++ b/lib/config/rules/stylistic-issues.js
@@ -15,6 +15,17 @@ module.exports = {
   camelcase: ['error', {properties: 'always'}],
   // Enforce or disallow capitalization of the first letter of a comment
   'capitalized-comments': 'off',
+  // Disallow or enforce trailing commas
+  'comma-dangle': [
+    'error',
+    {
+      arrays: 'always-multiline',
+      objects: 'always-multiline',
+      imports: 'always-multiline',
+      exports: 'always-multiline',
+      functions: 'always-multiline',
+    },
+  ],
   // Enforce spacing before and after comma
   'comma-spacing': ['error', {before: false, after: true}],
   // Enforce one true comma style

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/runtime-corejs2": "^7.4.3",
     "babel-preset-shopify": "^20.0.0",
     "chai": "^4.2.0",
-    "eslint": "^5.16.0",
+    "eslint": "^6.0.1",
     "eslint-find-rules": "^3.3.1",
     "eslint-index": "^1.5.0",
     "eslint-plugin-self": "^1.2.0",

--- a/tests/lib/rules/class-property-semi.js
+++ b/tests/lib/rules/class-property-semi.js
@@ -1,9 +1,9 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/class-property-semi');
 
-const ruleTester = new RuleTester();
-
-require('babel-eslint');
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+});
 
 const classPropNoSemi = 'class Foo { bar = 1 }';
 const classPropWithSemi = 'class Foo { bar = 1; }';
@@ -13,22 +13,20 @@ const classMethod = 'class Foo { bar() {} }';
 
 ruleTester.run('class-property-semi', rule, {
   valid: [
-    {code: classPropWithSemi, parser: 'babel-eslint'},
-    {code: classPropWithSemi, parser: 'babel-eslint', options: ['always']},
-    {code: classPropNoSemi, parser: 'babel-eslint', options: ['never']},
-    {code: classStaticPropWithSemi, parser: 'babel-eslint'},
+    {code: classPropWithSemi},
+    {code: classPropWithSemi, options: ['always']},
+    {code: classPropNoSemi, options: ['never']},
+    {code: classStaticPropWithSemi},
     {
       code: classStaticPropWithSemi,
-      parser: 'babel-eslint',
       options: ['always'],
     },
-    {code: classStaticPropNoSemi, parser: 'babel-eslint', options: ['never']},
+    {code: classStaticPropNoSemi, options: ['never']},
     {code: classMethod, parserOptions: {ecmaVersion: 6}},
   ],
   invalid: [
     {
       code: classPropNoSemi,
-      parser: 'babel-eslint',
       errors: [
         {
           message: 'Missing semicolon.',
@@ -38,7 +36,6 @@ ruleTester.run('class-property-semi', rule, {
     },
     {
       code: classPropNoSemi,
-      parser: 'babel-eslint',
       options: ['always'],
       errors: [
         {
@@ -49,7 +46,6 @@ ruleTester.run('class-property-semi', rule, {
     },
     {
       code: classPropWithSemi,
-      parser: 'babel-eslint',
       options: ['never'],
       errors: [
         {
@@ -60,7 +56,6 @@ ruleTester.run('class-property-semi', rule, {
     },
     {
       code: classStaticPropNoSemi,
-      parser: 'babel-eslint',
       errors: [
         {
           message: 'Missing semicolon.',
@@ -70,7 +65,6 @@ ruleTester.run('class-property-semi', rule, {
     },
     {
       code: classStaticPropNoSemi,
-      parser: 'babel-eslint',
       options: ['always'],
       errors: [
         {
@@ -81,7 +75,6 @@ ruleTester.run('class-property-semi', rule, {
     },
     {
       code: classStaticPropWithSemi,
-      parser: 'babel-eslint',
       options: ['never'],
       errors: [
         {

--- a/tests/lib/rules/jest/no-if.js
+++ b/tests/lib/rules/jest/no-if.js
@@ -1,9 +1,9 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../../lib/rules/jest/no-if');
-require('babel-eslint');
 
-const parser = 'babel-eslint';
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+});
 
 ruleTester.run('no-if', rule, {
   valid: [
@@ -12,43 +12,36 @@ ruleTester.run('no-if', rule, {
     },
     {
       code: `it('foo', () => {})`,
-      parser,
     },
     {
       code: `foo('bar', () => {
         if(baz) {}
       })`,
-      parser,
     },
     {
       code: `describe('foo', () => {
         if('bar') {}
       })`,
-      parser,
     },
     {
       code: `describe.skip('foo', () => {
         if('bar') {}
       })`,
-      parser,
     },
     {
       code: `describe('foo', () => {
         if('bar') {}
       })`,
-      parser,
     },
     {
       code: `xdescribe('foo', () => {
         if('bar') {}
       })`,
-      parser,
     },
     {
       code: `fdescribe('foo', () => {
         if('bar') {}
       })`,
-      parser,
     },
     {
       code: `describe('foo', () => {
@@ -56,7 +49,6 @@ ruleTester.run('no-if', rule, {
       })
       if('baz') {}
       `,
-      parser,
     },
     {
       code: `describe('foo', () => {
@@ -65,7 +57,6 @@ ruleTester.run('no-if', rule, {
           });
         })
       `,
-      parser,
     },
     {
       code: `describe('foo', () => {
@@ -74,11 +65,9 @@ ruleTester.run('no-if', rule, {
           });
         })
       `,
-      parser,
     },
     {
       code: `const foo = bar ? foo : baz;`,
-      parser,
     },
     {
       code: `
@@ -94,7 +83,6 @@ ruleTester.run('no-if', rule, {
         expect(values).toStrictEqual(['foo']);
       });
       `,
-      parser,
     },
     {
       code: `
@@ -112,7 +100,6 @@ ruleTester.run('no-if', rule, {
         });
       });
       `,
-      parser,
     },
     {
       code: `
@@ -132,14 +119,12 @@ ruleTester.run('no-if', rule, {
         });
       });
       `,
-      parser,
     },
     {
       code: `it('foo', () => {
         const foo = bar(() => qux ? qux() : false);
       });
       `,
-      parser,
     },
   ],
   invalid: [
@@ -147,7 +132,6 @@ ruleTester.run('no-if', rule, {
       code: `it('foo', () => {
         if('bar') {}
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -158,7 +142,6 @@ ruleTester.run('no-if', rule, {
       code: `it.skip('foo', () => {
         if('bar') {}
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -169,7 +152,6 @@ ruleTester.run('no-if', rule, {
       code: `it.only('foo', () => {
         if('bar') {}
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -180,7 +162,6 @@ ruleTester.run('no-if', rule, {
       code: `xit('foo', () => {
         if('bar') {}
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -191,7 +172,6 @@ ruleTester.run('no-if', rule, {
       code: `fit('foo', () => {
         if('bar') {}
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -202,7 +182,6 @@ ruleTester.run('no-if', rule, {
       code: `test('foo', () => {
         if('bar') {}
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -213,7 +192,6 @@ ruleTester.run('no-if', rule, {
       code: `test.skip('foo', () => {
         if('bar') {}
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -224,7 +202,6 @@ ruleTester.run('no-if', rule, {
       code: `test.only('foo', () => {
         if('bar') {}
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -235,7 +212,6 @@ ruleTester.run('no-if', rule, {
       code: `xtest('foo', () => {
         if('bar') {}
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -248,7 +224,6 @@ ruleTester.run('no-if', rule, {
           if('bar') {}
         })
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -265,7 +240,6 @@ ruleTester.run('no-if', rule, {
           if('quux') {}
         })
       })`,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -284,7 +258,6 @@ ruleTester.run('no-if', rule, {
         if ('bar') {}
       })
       `,
-      parser,
       errors: [
         {
           messageId: 'noIf',
@@ -296,7 +269,6 @@ ruleTester.run('no-if', rule, {
         const foo = bar ? foo : baz;
       })
       `,
-      parser,
       errors: [
         {
           messageId: 'noConditional',
@@ -309,7 +281,6 @@ ruleTester.run('no-if', rule, {
       })
       const foo = bar ? foo : baz;
       `,
-      parser,
       errors: [
         {
           messageId: 'noConditional',
@@ -322,7 +293,6 @@ ruleTester.run('no-if', rule, {
         const anotherFoo = anotherBar ? anotherFoo : anotherBaz;
       })
       `,
-      parser,
       errors: [
         {
           messageId: 'noConditional',
@@ -352,7 +322,6 @@ ruleTester.run('no-if', rule, {
         });
       });
       `,
-      parser,
       errors: [
         {
           messageId: 'noIf',

--- a/tests/lib/rules/jest/no-try-expect.js
+++ b/tests/lib/rules/jest/no-try-expect.js
@@ -1,9 +1,9 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../../lib/rules/jest/no-try-expect');
-require('babel-eslint');
 
-const parser = 'babel-eslint';
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+});
 
 ruleTester.run('no-try-expect', rule, {
   valid: [
@@ -11,7 +11,6 @@ ruleTester.run('no-try-expect', rule, {
       code: `it('foo', () => {
         expect('foo').toEqual('foo');
       })`,
-      parser,
     },
     {
       code: `
@@ -23,7 +22,6 @@ ruleTester.run('no-try-expect', rule, {
         } catch {
           expect('foo').toEqual('foo');
         }`,
-      parser,
     },
     {
       code: `
@@ -33,7 +31,6 @@ ruleTester.run('no-try-expect', rule, {
         } catch {
           expect('foo').toEqual('foo');
         }`,
-      parser,
     },
   ],
   invalid: [
@@ -45,7 +42,6 @@ ruleTester.run('no-try-expect', rule, {
           expect(err).toMatch('Error');
         }
       })`,
-      parser,
       errors: [
         {
           messageId: 'noTryExpect',
@@ -62,7 +58,6 @@ ruleTester.run('no-try-expect', rule, {
           }
         })
       })`,
-      parser,
       errors: [
         {
           messageId: 'noTryExpect',

--- a/tests/lib/rules/jest/no-vague-titles.js
+++ b/tests/lib/rules/jest/no-vague-titles.js
@@ -1,150 +1,112 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../../lib/rules/jest/no-vague-titles');
 
-const ruleTester = new RuleTester();
-
-require('babel-eslint');
-require('typescript-eslint-parser');
-
-const typeScriptParser = 'typescript-eslint-parser';
-const parser = 'babel-eslint';
+const ruleTester = new RuleTester({parser: require.resolve('babel-eslint')});
 
 ruleTester.run('no-vague-titles', rule, {
   valid: [
     {
       code: `it()`,
-      parser,
     },
     {
       code: `it('')`,
-      parser,
     },
     {
       code: `it('foo bar baz')`,
-      parser,
     },
     {
       code: `xit('foo bar baz')`,
-      parser,
     },
     {
       code: `it.only('foo bar baz')`,
-      parser,
     },
     {
       code: `describe('foo bar baz')`,
-      parser,
     },
     {
       code: `describe('closing foo does not call bar')`,
-      parser,
     },
     {
       code: `xdescribe('foo bar baz')`,
-      parser,
     },
     {
       code: `describe.only('foo bar baz')`,
-      parser,
     },
     {
       code: `test('foo bar baz')`,
-      parser,
     },
     {
       code: `xtest('foo bar baz')`,
-      parser,
     },
     {
       code: `test.only('foo bar baz')`,
-      parser,
     },
     {
       code: `someFunction('correct')`,
-      parser,
     },
     {
       code: `someFunction('incorrect')`,
-      parser,
     },
     {
       code: `someFunction('correctly')`,
-      parser,
     },
     {
       code: `someFunction('incorrectly')`,
-      parser,
     },
     {
       code: `someFunction('Correct')`,
-      parser,
     },
     {
       code: `someFunction('appropriate')`,
-      parser,
     },
     {
       code: `someFunction('inappropriate')`,
-      parser,
     },
     {
       code: `someFunction('Appropriate')`,
-      parser,
     },
     {
       code: `someFunction('appropriately')`,
-      parser,
     },
     {
       code: `someFunction.only('correct')`,
-      parser,
     },
     {
       code: `someFunction('Includes all the expected things')`,
-      parser,
     },
     {
       code: `someFunction('All the expected things are included')`,
-      parser,
     },
     {
       code: `someFunction.only('Includes all the expected things')`,
-      parser,
     },
     {
       code: `(() => {})()`,
-      parser,
     },
     {
       code: "it('onAllImagesUploaded')",
-      parser,
     },
     {
       code: `test.each([['production'], ['staging']])('Includes things for %s clients')`,
-      parser,
     },
     {
       code: `import('./foo')`,
-      parser,
     },
     {
       code: 'foo(bar)()',
-      parser,
     },
     {
       code: 'class Foo { constructor() { super(); } }',
-      parser,
     },
     {
       code: '(Foo as Function)();',
-      parser: typeScriptParser,
+      parser: require.resolve('typescript-eslint-parser'),
     },
   ],
   invalid: [
     {
       code:
         "it('properly should correcly appropriate all descriptive necessary')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -153,7 +115,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('necessary')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -162,7 +123,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('necessary')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -171,7 +131,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('necessary')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -180,7 +139,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('necessary')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -189,7 +147,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('necessary')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -198,7 +155,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('properly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -207,7 +163,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('properly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -216,7 +171,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('properly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -225,7 +179,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('properly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -234,7 +187,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('properly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -243,7 +195,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('should')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -252,7 +203,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('should')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -261,7 +211,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('should')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -270,7 +219,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('should')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -279,7 +227,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('should')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -288,7 +235,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('descriptive')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -297,7 +243,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('descriptive')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -306,7 +251,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('descriptive')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -315,7 +259,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('descriptive')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -324,7 +267,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('descriptive')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -333,7 +275,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('every')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -342,7 +283,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('every')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -351,7 +291,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('every')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -360,7 +299,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('every')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -369,7 +307,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('every')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -378,7 +315,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -387,7 +323,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('correctly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -396,7 +331,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('incorrect')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -405,7 +339,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('Correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -414,7 +347,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('correctly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -423,7 +355,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('incorrect')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -432,7 +363,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('Correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -441,7 +371,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('All the expected things are included')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -450,7 +379,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -459,7 +387,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('Includes all the expected things')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -468,7 +395,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('correctly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -477,7 +403,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('incorrect')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -486,7 +411,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('Correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -495,7 +419,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -504,7 +427,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('Includes all the expected things')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -513,7 +435,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('correctly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -522,7 +443,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('incorrect')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -531,7 +451,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('Correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -541,7 +460,6 @@ ruleTester.run('no-vague-titles', rule, {
 
     {
       code: "describe.only('correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -551,7 +469,6 @@ ruleTester.run('no-vague-titles', rule, {
 
     {
       code: "describe.only('correctly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -560,7 +477,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe.only('incorrect')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -569,7 +485,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe.only('Correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -578,7 +493,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe.only('Includes all the expected things')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -587,7 +501,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -596,7 +509,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('correctly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -605,7 +517,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('incorrect')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -614,7 +525,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('Correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -624,7 +534,6 @@ ruleTester.run('no-vague-titles', rule, {
 
     {
       code: "xtest('correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -633,7 +542,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('Includes all the expected things')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -642,7 +550,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('correctly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -651,7 +558,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('incorrect')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -660,7 +566,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('Correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -669,7 +574,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test.only('correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -678,7 +582,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test.only('correctly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -687,7 +590,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test.only('incorrect')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -696,7 +598,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test.only('Correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -705,7 +606,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -714,7 +614,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('appropriately')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -723,7 +622,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('inappropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -732,7 +630,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('Appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -741,7 +638,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -750,7 +646,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('appropriately')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -759,7 +654,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('inappropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -768,7 +662,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('Appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -777,7 +670,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -786,7 +678,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -795,7 +686,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('appropriately')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -804,7 +694,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('inappropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -813,7 +702,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "fit('Appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -822,7 +710,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -831,7 +718,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -840,7 +726,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('appropriately')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -849,7 +734,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('inappropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -858,7 +742,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('Appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -867,7 +750,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -876,7 +758,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -885,7 +766,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('appropriately')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -894,7 +774,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('inappropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -903,7 +782,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('Appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -912,7 +790,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -921,7 +798,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -930,7 +806,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('appropriately')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -939,7 +814,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('inappropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -948,7 +822,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('Appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -957,7 +830,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: `test.each([['production'], ['staging']])('all correct for %s')`,
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -966,7 +838,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -975,7 +846,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -984,7 +854,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('appropriately')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -993,7 +862,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('inappropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1002,7 +870,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xtest('Appropriate')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1011,7 +878,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: `xtest.each([['production'], ['staging']])('all correct for %s')`,
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1020,7 +886,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('Includes all the expected things')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1029,7 +894,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('All the expected things are included')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1038,7 +902,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it.only('correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1047,7 +910,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it.only('Includes all the expected things')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1056,7 +918,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it.only('correctly')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1065,7 +926,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it.only('incorrect')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1074,7 +934,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it.only('Correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1083,7 +942,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it.only('All the expected things are included')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1092,7 +950,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: `it.each([['production'], ['staging']])('all correct for %s')`,
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1101,7 +958,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('correct')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1110,7 +966,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xit('Includes all the expected things')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1119,7 +974,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: `xit.each([['production'], ['staging']])('all correct for %s')`,
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1128,7 +982,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe('All the expected things are included')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1137,7 +990,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "xdescribe('All the expected things are included')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1146,7 +998,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: `xdescribe.each([['production'], ['staging']])('all correct for %s')`,
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1155,7 +1006,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "describe.only('Includes all the expected things')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1164,7 +1014,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: `describe.each([['production'], ['staging']])('all correct for %s')`,
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1173,7 +1022,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test('All the expected things are included')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1182,7 +1030,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "test.only('Includes all the expected things')",
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -1191,7 +1038,6 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: `test.each([['production'], ['staging']])('Includes all things for %s clients')`,
-      parser,
       errors: [
         {
           messageId: 'containsVagueWord',

--- a/tests/lib/rules/jsx-no-hardcoded-content.js
+++ b/tests/lib/rules/jsx-no-hardcoded-content.js
@@ -2,11 +2,7 @@ const {RuleTester} = require('eslint');
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/jsx-no-hardcoded-content');
 
-const ruleTester = new RuleTester();
-
-require('babel-eslint');
-
-const parser = 'babel-eslint';
+const ruleTester = new RuleTester({parser: require.resolve('babel-eslint')});
 
 function errorsFor(component, prop) {
   const message =
@@ -23,113 +19,94 @@ const checkProps = {checkProps: ['foo']};
 
 ruleTester.run('jsx-no-hardcoded-content', rule, {
   valid: [
-    {code: '<div />', parser},
-    {code: '<div aria-label={someVariable} />', parser},
-    {code: '<div title={someVariable} />', parser},
-    {code: '<img alt={someVariable} />', parser},
-    {code: '<input placeholder={someVariable} />', parser},
+    {code: '<div />'},
+    {code: '<div aria-label={someVariable} />'},
+    {code: '<div title={someVariable} />'},
+    {code: '<img alt={someVariable} />'},
+    {code: '<input placeholder={someVariable} />'},
     {
       code: `<div>
         <div />
       </div>`,
-      parser,
     },
-    {code: '<MyComponent />', parser},
+    {code: '<MyComponent />'},
     {
       code: `<MyComponent>
         <div />
       </MyComponent>`,
-      parser,
     },
-    {code: '<MyComponent>{true}</MyComponent>', parser},
-    {code: '<MyComponent>{2}</MyComponent>', parser},
-    {code: '<MyComponent>{true}</MyComponent>', parser},
+    {code: '<MyComponent>{true}</MyComponent>'},
+    {code: '<MyComponent>{2}</MyComponent>'},
+    {code: '<MyComponent>{true}</MyComponent>'},
     {
       code: '<MyComponent>Content</MyComponent>',
-      parser,
       options: [allowStrings],
     },
     {
       code: '<MyComponent>{"Content"}</MyComponent>',
-      parser,
       options: [allowStrings],
     },
-    {code: '<MyComponent>{someVariable}</MyComponent>', parser},
-    {code: '<MyComponent>{someFunction()}</MyComponent>', parser},
-    {code: '<MyComponent>{this.someMethod()}</MyComponent>', parser},
+    {code: '<MyComponent>{someVariable}</MyComponent>'},
+    {code: '<MyComponent>{someFunction()}</MyComponent>'},
+    {code: '<MyComponent>{this.someMethod()}</MyComponent>'},
     {
       code: '<MyComponent>{someVariable} Content</MyComponent>',
-      parser,
       options: [allowStrings],
     },
     {
       code: '<MyComponent>{someFunction()}{" Content"}</MyComponent>',
-      parser,
       options: [allowStrings],
     },
     {
       code: '<MyComponent>{someFunction()}{` Content`}</MyComponent>',
-      parser,
       options: [allowStrings],
     },
     {
       code: '<MyComponent>{someFunction()}{" Content"}</MyComponent>',
-      parser,
       options: [{...allowStrings, ...disallowNumbers}],
     },
     {
       code: '<MyComponent foo />',
-      parser,
       options: [checkProps],
     },
     {
       code: '<MyComponent foo={false} />',
-      parser,
       options: [checkProps],
     },
     {
       code: '<MyComponent foo={42} />',
-      parser,
       options: [checkProps],
     },
     {
       code: '<MyComponent foo={someFunction()} />',
-      parser,
       options: [checkProps],
     },
     {
       code: '<MyComponent foo={someVariable} />',
-      parser,
       options: [checkProps],
     },
     {
       code: '<MyComponent foo="bar" />',
-      parser,
       options: [{...checkProps, ...allowStrings}],
     },
     {
       code: '<MyComponent foo={"bar"} />',
-      parser,
       options: [{...checkProps, ...allowStrings}],
     },
     {
       code: "<MyComponent foo={'bar'} />",
-      parser,
       options: [{...checkProps, ...allowStrings}],
     },
     {
       code: '<MyComponent foo={`bar`} />',
-      parser,
       options: [{...checkProps, ...allowStrings}],
     },
     {
       code: '<MyComponent foo={`bar`} />',
-      parser,
       options: [{...checkProps, ...allowStrings}],
     },
     {
       code: '<MyComponent>{42}</MyComponent>',
-      parser,
       options: [
         {
           modules: {
@@ -143,7 +120,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         import {MyComponent} from 'other-module';
         <MyComponent>{42}</MyComponent>
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -158,7 +134,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         import {MyComponent} from 'my-module';
         <MyComponent>{42}</MyComponent>
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -170,7 +145,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
     },
     {
       code: '<MyComponent foo="bar" />',
-      parser,
       options: [
         {
           modules: {
@@ -184,7 +158,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         import {MyComponent} from 'other-module';
         <MyComponent foo="bar" />
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -199,7 +172,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         import {MyComponent} from 'my-module';
         <MyComponent foo="bar" />
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -214,7 +186,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         import {MyComponent} from 'my-module';
         <MyComponent>Content</MyComponent>
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -229,7 +200,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         import {MyComponent as Aliased} from 'my-module';
         <Aliased>Content</Aliased>
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -245,7 +215,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         function MyComponent() {}
         <MyComponent>{42}</MyComponent>
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -261,7 +230,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>Content</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       settings: {
         'import/resolver': {
           node: {
@@ -283,7 +251,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>Content</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -298,7 +265,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>Content</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -315,7 +281,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>Content</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -332,7 +297,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>Content</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -349,7 +313,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <Polaris.MyComponent>Content</Polaris.MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -366,7 +329,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent.Subcomponent>Content</MyComponent.Subcomponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -383,7 +345,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent.Subcomponent>Content</MyComponent.Subcomponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -398,27 +359,22 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
   invalid: [
     {
       code: '<div aria-label="Content" />',
-      parser,
       errors: errorsFor('div', 'aria-label'),
     },
     {
       code: '<div title="Content" />',
-      parser,
       errors: errorsFor('div', 'title'),
     },
     {
       code: '<img alt="Content" />',
-      parser,
       errors: errorsFor('img', 'alt'),
     },
     {
       code: '<input placeholder="Content" />',
-      parser,
       errors: errorsFor('input', 'placeholder'),
     },
     {
       code: '<my-element placeholder="Content" />',
-      parser,
       errors: errorsFor('my-element', 'placeholder'),
       options: [
         {
@@ -432,62 +388,51 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
     },
     {
       code: '<MyComponent>Content</MyComponent>',
-      parser,
       errors: errorsFor('MyComponent', 'children'),
     },
     {
       code: '<MyComponent>{"Content"}</MyComponent>',
-      parser,
       errors: errorsFor('MyComponent', 'children'),
     },
     {
       code: '<MyComponent>{`Content`}</MyComponent>',
-      parser,
       errors: errorsFor('MyComponent', 'children'),
     },
     {
       code: '<MyComponent>{someFunction()} Content</MyComponent>',
-      parser,
       errors: errorsFor('MyComponent', 'children'),
     },
     {
       code: '<MyComponent>{someFunction()}{" Content"}</MyComponent>',
-      parser,
       errors: errorsFor('MyComponent', 'children'),
     },
     {
       code: '<MyComponent>{3}</MyComponent>',
-      parser,
       options: [disallowNumbers],
       errors: errorsFor('MyComponent', 'children'),
     },
     {
       code: '<MyComponent foo={42} />',
-      parser,
       options: [{...checkProps, ...disallowNumbers}],
       errors: errorsFor('MyComponent', 'foo'),
     },
     {
       code: '<MyComponent foo="bar" />',
-      parser,
       options: [checkProps],
       errors: errorsFor('MyComponent', 'foo'),
     },
     {
       code: '<MyComponent foo={"bar"} />',
-      parser,
       options: [checkProps],
       errors: errorsFor('MyComponent', 'foo'),
     },
     {
       code: "<MyComponent foo={'bar'} />",
-      parser,
       options: [checkProps],
       errors: errorsFor('MyComponent', 'foo'),
     },
     {
       code: '<MyComponent foo={`bar`} />',
-      parser,
       options: [checkProps],
       errors: errorsFor('MyComponent', 'foo'),
     },
@@ -496,7 +441,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         import {MyComponent} from 'my-module';
         <MyComponent>Content</MyComponent>
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -512,7 +456,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         import {MyComponent} from 'my-module';
         <MyComponent>Content</MyComponent>
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -529,7 +472,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         import {MyComponent as Aliased} from 'my-module';
         <Aliased>Content</Aliased>
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -546,7 +488,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         function MyComponent() {}
         <MyComponent>Content</MyComponent>
       `,
-      parser,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
       options: [
         {
@@ -563,7 +504,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>Content</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -581,7 +521,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>Content</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -599,7 +538,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>Content</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -617,7 +555,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>{42}</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -635,7 +572,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent>{42}</MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -653,7 +589,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <Polaris.MyComponent>Content</Polaris.MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -671,7 +606,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <Polaris.MyComponent>{42}</Polaris.MyComponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -689,7 +623,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent.Subcomponent>{42}</MyComponent.Subcomponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -707,7 +640,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent.Subcomponent>Content</MyComponent.Subcomponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -725,7 +657,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent.Subcomponent>{42}</MyComponent.Subcomponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {
@@ -743,7 +674,6 @@ ruleTester.run('jsx-no-hardcoded-content', rule, {
         <MyComponent.Subcomponent>Content</MyComponent.Subcomponent>
       `,
       filename: fixtureFile('basic-app/app/sections/MySection/MySection.js'),
-      parser,
       options: [
         {
           modules: {

--- a/tests/lib/rules/jsx-prefer-fragment-wrappers.js
+++ b/tests/lib/rules/jsx-prefer-fragment-wrappers.js
@@ -1,10 +1,8 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/jsx-prefer-fragment-wrappers');
 
-require('babel-eslint');
+const ruleTester = new RuleTester({parser: require.resolve('babel-eslint')});
 
-const parser = 'babel-eslint';
-const ruleTester = new RuleTester();
 function errorWithTagName(tagName) {
   return [
     {
@@ -16,46 +14,38 @@ function errorWithTagName(tagName) {
 
 ruleTester.run('jsx-prefer-fragment-wrappers', rule, {
   valid: [
-    {code: '<div className={className}>{foo}{bar}<Baz /></div>', parser},
-    {code: '<div><Bar /></div>', parser},
-    {code: '<Foo><Bar /><Baz /></Foo>', parser},
-    {code: '<Foo>{someFunction()}</Foo>', parser},
-    {code: '<Foo>Some content</Foo>', parser},
+    {code: '<div className={className}>{foo}{bar}<Baz /></div>'},
+    {code: '<div><Bar /></div>'},
+    {code: '<Foo><Bar /><Baz /></Foo>'},
+    {code: '<Foo>{someFunction()}</Foo>'},
+    {code: '<Foo>Some content</Foo>'},
     {
       code: '<React.Fragment><Foo /><Bar /><Baz /></React.Fragment>',
-      parser,
     },
     {
       code: '<><Foo /><Bar /><Baz /></>',
-      parser,
     },
     {
       code: '<Foo.Bar><Foo /><Bar /><Baz /></Foo.Bar>',
-      parser,
     },
     {
       code: '<table><tbody /><thead /></table>',
-      parser,
     },
     {
       code: '<tr><td>data</td><td>more data</td></tr>',
-      parser,
     },
   ],
   invalid: [
     {
       code: '<span>{things}{things}</span>',
-      parser,
       errors: errorWithTagName('span'),
     },
     {
       code: '<div>{things}{things}</div>',
-      parser,
       errors: errorWithTagName('div'),
     },
     {
       code: '<div><Foo /><Bar /><Baz><Foo /></Baz></div>',
-      parser,
       errors: errorWithTagName('div'),
     },
   ],

--- a/tests/lib/rules/no-fully-static-classes.js
+++ b/tests/lib/rules/no-fully-static-classes.js
@@ -1,11 +1,7 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/no-fully-static-classes');
 
-const ruleTester = new RuleTester();
-
-require('babel-eslint');
-
-const parser = 'babel-eslint';
+const ruleTester = new RuleTester({parser: require.resolve('babel-eslint')});
 
 function method(name = 'foo') {
   return `${name}() {}`;
@@ -37,109 +33,93 @@ ruleTester.run('prefer-class-properties', rule, {
         ${method('foo')}
         ${method('bar')}
       }`,
-      parser,
     },
     {
       code: `class Foo {
         ${staticMethod('foo')}
         ${method('bar')}
       }`,
-      parser,
     },
     {
       code: `class Foo {
         ${property('foo')}
         ${property('bar')}
       }`,
-      parser,
     },
     {
       code: `class Foo {
         ${property('foo')}
         ${staticProperty('bar')}
       }`,
-      parser,
     },
     {
       code: `class Foo {
         ${method('foo')}
         ${property('bar')}
       }`,
-      parser,
     },
     {
       code: `class Foo {
         ${method('foo')}
         ${staticProperty('bar')}
       }`,
-      parser,
     },
     {
       code: `class Foo {
         ${staticMethod('foo')}
         ${property('bar')}
       }`,
-      parser,
     },
     {
       code: `const Foo = class {
         ${method('foo')}
         ${method('bar')}
       }`,
-      parser,
     },
     {
       code: `const Foo = class {
         ${staticMethod('foo')}
         ${method('bar')}
       }`,
-      parser,
     },
     {
       code: `const Foo = class {
         ${property('foo')}
         ${property('bar')}
       }`,
-      parser,
     },
     {
       code: `const Foo = class {
         ${property('foo')}
         ${staticProperty('bar')}
       }`,
-      parser,
     },
     {
       code: `const Foo = class {
         ${method('foo')}
         ${property('bar')}
       }`,
-      parser,
     },
     {
       code: `const Foo = class {
         ${method('foo')}
         ${staticProperty('bar')}
       }`,
-      parser,
     },
     {
       code: `const Foo = class {
         ${staticMethod('foo')}
         ${property('bar')}
       }`,
-      parser,
     },
     {
       code: 'class Foo {}',
-      parser,
     },
     {
       code: `class Foo extends Bar {
         ${staticMethod('foo')}
         ${staticProperty('bar')}
       }`,
-      parser,
     },
   ],
   invalid: [
@@ -148,7 +128,6 @@ ruleTester.run('prefer-class-properties', rule, {
         ${staticMethod('foo')}
         ${staticMethod('bar')}
       }`,
-      parser,
       errors: errorWithType('ClassDeclaration'),
     },
     {
@@ -156,7 +135,6 @@ ruleTester.run('prefer-class-properties', rule, {
         ${staticProperty('foo')}
         ${staticProperty('bar')}
       }`,
-      parser,
       errors: errorWithType('ClassDeclaration'),
     },
     {
@@ -164,7 +142,6 @@ ruleTester.run('prefer-class-properties', rule, {
         ${staticProperty('foo')}
         ${staticMethod('bar')}
       }`,
-      parser,
       errors: errorWithType('ClassDeclaration'),
     },
     {
@@ -172,7 +149,6 @@ ruleTester.run('prefer-class-properties', rule, {
         ${staticMethod('foo')}
         ${staticMethod('bar')}
       }`,
-      parser,
       errors: errorWithType('ClassExpression'),
     },
     {
@@ -180,7 +156,6 @@ ruleTester.run('prefer-class-properties', rule, {
         ${staticProperty('foo')}
         ${staticProperty('bar')}
       }`,
-      parser,
       errors: errorWithType('ClassExpression'),
     },
     {
@@ -188,7 +163,6 @@ ruleTester.run('prefer-class-properties', rule, {
         ${staticProperty('foo')}
         ${staticMethod('bar')}
       }`,
-      parser,
       errors: errorWithType('ClassExpression'),
     },
   ],

--- a/tests/lib/rules/no-useless-computed-properties.js
+++ b/tests/lib/rules/no-useless-computed-properties.js
@@ -1,80 +1,74 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/no-useless-computed-properties');
-require('babel-eslint');
 
-const ruleTester = new RuleTester();
-
-const parserOptions = {ecmaVersion: 6};
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
 const message = 'Computed property is using a literal key unnecessarily.';
 
 ruleTester.run('no-useless-computed-properties', rule, {
   valid: [
     {code: 'var foo = {"bar": true}'},
     {code: 'var foo = {bar: true}'},
-    {code: 'var foo = {[bar]: true}', parserOptions},
-    {code: 'var foo = {[bar()]: true}', parserOptions},
+    {code: 'var foo = {[bar]: true}'},
+    {code: 'var foo = {[bar()]: true}'},
     {code: 'var foo = {123: true}'},
 
-    {code: 'var foo = {"bar"() {}}', parserOptions},
-    {code: 'var foo = {bar() {}}', parserOptions},
-    {code: 'var foo = {[bar]() {}}', parserOptions},
-    {code: 'var foo = {[bar()]() {}}', parserOptions},
-    {code: 'var foo = {123() {}}', parserOptions},
+    {code: 'var foo = {"bar"() {}}'},
+    {code: 'var foo = {bar() {}}'},
+    {code: 'var foo = {[bar]() {}}'},
+    {code: 'var foo = {[bar()]() {}}'},
+    {code: 'var foo = {123() {}}'},
 
-    {code: 'class Foo {"bar"() {}}', parserOptions},
-    {code: 'class Foo {bar() {}}', parserOptions},
-    {code: 'class Foo {[bar]() {}}', parserOptions},
-    {code: 'class Foo {[bar()]() {}}', parserOptions},
-    {code: 'class Foo {123() {}}', parserOptions},
+    {code: 'class Foo {"bar"() {}}'},
+    {code: 'class Foo {bar() {}}'},
+    {code: 'class Foo {[bar]() {}}'},
+    {code: 'class Foo {[bar()]() {}}'},
+    {code: 'class Foo {123() {}}'},
 
-    {code: 'class Foo {static "bar"() {}}', parser: 'babel-eslint'},
-    {code: 'class Foo {static bar() {}}', parser: 'babel-eslint'},
-    {code: 'class Foo {static [bar]() {}}', parser: 'babel-eslint'},
-    {code: 'class Foo {static [bar()]() {}}', parser: 'babel-eslint'},
-    {code: 'class Foo {static 123() {}}', parser: 'babel-eslint'},
+    {code: 'class Foo {static "bar"() {}}'},
+    {code: 'class Foo {static bar() {}}'},
+    {code: 'class Foo {static [bar]() {}}'},
+    {code: 'class Foo {static [bar()]() {}}'},
+    {code: 'class Foo {static 123() {}}'},
   ],
   invalid: [
     {
       code: 'var foo = {["bar"]: true}',
-      parserOptions,
       errors: [{message, type: 'Property'}],
     },
     {
       code: 'var foo = {[123]: true}',
-      parserOptions,
       errors: [{message, type: 'Property'}],
     },
 
     {
       code: 'var foo = {["bar"]() {}}',
-      parserOptions,
       errors: [{message, type: 'Property'}],
     },
     {
       code: 'var foo = {[123]() {}}',
-      parserOptions,
       errors: [{message, type: 'Property'}],
     },
 
     {
       code: 'class Foo {["bar"]() {}}',
-      parserOptions,
       errors: [{message, type: 'MethodDefinition'}],
     },
     {
       code: 'class Foo {[123]() {}}',
-      parserOptions,
       errors: [{message, type: 'MethodDefinition'}],
     },
 
     {
       code: 'class Foo {static ["bar"]() {}}',
-      parser: 'babel-eslint',
       errors: [{message, type: 'MethodDefinition'}],
     },
     {
       code: 'class Foo {static [123]() {}}',
-      parser: 'babel-eslint',
       errors: [{message, type: 'MethodDefinition'}],
     },
   ],

--- a/tests/lib/rules/prefer-class-properties.js
+++ b/tests/lib/rules/prefer-class-properties.js
@@ -1,13 +1,12 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/prefer-class-properties');
 
-const ruleTester = new RuleTester();
-
-require('babel-eslint');
-
-const parserOptions = {
-  ecmaVersion: 6,
-};
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
 
 const classPropErrors = [
   {
@@ -27,27 +26,22 @@ ruleTester.run('prefer-class-properties', rule, {
   valid: [
     {
       code: 'class Foo { foo = "bar"; }',
-      parser: 'babel-eslint',
       options: ['always'],
     },
     {
       code: 'class Foo { foo = bar(); }',
-      parser: 'babel-eslint',
       options: ['always'],
     },
     {
       code: 'class Foo { foo = 123; }',
-      parser: 'babel-eslint',
       options: ['always'],
     },
     {
       code: 'class Foo { static foo = "bar"; }',
-      parser: 'babel-eslint',
       options: ['never'],
     },
     {
       code: 'class Foo { static foo = "bar"; }',
-      parser: 'babel-eslint',
       options: ['always'],
     },
     {
@@ -56,7 +50,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = 123;
         }
       }`,
-      parserOptions,
       options: ['never'],
     },
     {
@@ -65,7 +58,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = '123';
         }
       }`,
-      parserOptions,
       options: ['never'],
     },
     {
@@ -74,7 +66,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this[foo] = 123;
         }
       }`,
-      parserOptions,
       options: ['always'],
     },
     {
@@ -83,7 +74,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo[bar].baz = 123;
         }
       }`,
-      parserOptions,
       options: ['always'],
     },
     {
@@ -92,7 +82,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = foo();
         }
       }`,
-      parserOptions,
       options: ['always'],
     },
     {
@@ -103,7 +92,6 @@ ruleTester.run('prefer-class-properties', rule, {
           }
         }
       }`,
-      parserOptions,
       options: ['always'],
     },
     {
@@ -112,7 +100,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = 123;
         }
       }`,
-      parserOptions,
       options: ['always'],
     },
     {
@@ -121,7 +108,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = [123, bar, 456];
         }
       }`,
-      parserOptions,
       options: ['always'],
     },
     {
@@ -130,7 +116,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = {foo: 123, bar: baz};
         }
       }`,
-      parserOptions,
       options: ['always'],
     },
     {
@@ -139,26 +124,22 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = {[foo]: 123};
         }
       }`,
-      parserOptions,
       options: ['always'],
     },
   ],
   invalid: [
     {
       code: 'class Foo { foo = "bar"; }',
-      parser: 'babel-eslint',
       options: ['never'],
       errors: classPropErrors,
     },
     {
       code: 'class Foo { foo = bar(); }',
-      parser: 'babel-eslint',
       options: ['never'],
       errors: classPropErrors,
     },
     {
       code: 'class Foo { foo = 123; }',
-      parser: 'babel-eslint',
       options: ['never'],
       errors: classPropErrors,
     },
@@ -168,7 +149,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = 123;
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -178,7 +158,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = false;
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -188,7 +167,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = /something/;
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -198,7 +176,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = '123';
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -208,7 +185,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = '123'.toUpperCase();
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -218,7 +194,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = [];
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -228,7 +203,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = {};
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -238,7 +212,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = [123, 456, 789];
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -248,7 +221,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = [123, [456, 789]];
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -258,7 +230,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this.foo = {foo: 123, bar: {baz: '456'}};
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },
@@ -268,7 +239,6 @@ ruleTester.run('prefer-class-properties', rule, {
           this['foo'] = 123;
         }
       }`,
-      parserOptions,
       errors: assignErrors,
       options: ['always'],
     },

--- a/tests/lib/rules/react-hooks-strict-return.js
+++ b/tests/lib/rules/react-hooks-strict-return.js
@@ -1,11 +1,8 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/react-hooks-strict-return');
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({parser: require.resolve('babel-eslint')});
 
-require('babel-eslint');
-
-const parser = 'babel-eslint';
 const errors = [
   {
     messageId: 'hooksStrictReturn',
@@ -19,14 +16,12 @@ ruleTester.run('react-hooks-strict-return', rule, {
         return [1]
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
         return [1, 2]
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
@@ -34,7 +29,6 @@ ruleTester.run('react-hooks-strict-return', rule, {
         return bar;
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
@@ -42,14 +36,12 @@ ruleTester.run('react-hooks-strict-return', rule, {
         return [...bar];
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
           return ['bar', () => {}]
         }
         `,
-      parser,
     },
     {
       code: `function useFoo() {
@@ -58,14 +50,12 @@ ruleTester.run('react-hooks-strict-return', rule, {
         return [...bar, ...baz];
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
         return {one: 1, two: 2, three: 3}
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
@@ -73,7 +63,6 @@ ruleTester.run('react-hooks-strict-return', rule, {
         return bar
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
@@ -81,7 +70,6 @@ ruleTester.run('react-hooks-strict-return', rule, {
         return {...bar}
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
@@ -89,45 +77,38 @@ ruleTester.run('react-hooks-strict-return', rule, {
         return {...bar, four: 4}
       }
       `,
-      parser,
     },
     {
       code: `function foo() {
         return [1, 2, 3]
       }
       `,
-      parser,
     },
     {
       code: `function foo() {
         return [0, {one: 1, two: 2, three: 3}, 4, 5,]
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
         return null
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {
         return 1
       }
       `,
-      parser,
     },
     {
       code: `function useFoo() {}`,
-      parser,
     },
     {
       code: `function useFoo() {
         return 'bar';
       }`,
-      parser,
     },
     {
       code: `function useFoo() {
@@ -136,24 +117,20 @@ ruleTester.run('react-hooks-strict-return', rule, {
       function baz() {
         return [1, 2, 3, 4]
       }`,
-      parser,
     },
     {
       code: `function useFoo() {
         const bar = 1;
         return [bar, () => {}];
       }`,
-      parser,
     },
     {
       code: `function useHookWithNoReturn() {}`,
-      parser,
     },
     {
       code: `function useHookUndefinedReturn() {
         return;
       }`,
-      parser,
     },
   ],
   invalid: [
@@ -161,7 +138,6 @@ ruleTester.run('react-hooks-strict-return', rule, {
       code: `function useFoo() {
         return [1, 2, 3]
       }`,
-      parser,
       errors,
     },
     {
@@ -169,7 +145,6 @@ ruleTester.run('react-hooks-strict-return', rule, {
         const bar = [1, 2, 3]
         return bar;
       }`,
-      parser,
       errors,
     },
     {
@@ -177,14 +152,12 @@ ruleTester.run('react-hooks-strict-return', rule, {
         const bar = [1, 2, 3]
         return bar;
       }`,
-      parser,
       errors,
     },
     {
       code: `function useFoo() {
         return [,,,]
       }`,
-      parser,
       errors,
     },
     {
@@ -192,7 +165,6 @@ ruleTester.run('react-hooks-strict-return', rule, {
         const bar = [1, 2, 3]
         return [...bar]
       }`,
-      parser,
       errors,
     },
     {
@@ -200,7 +172,6 @@ ruleTester.run('react-hooks-strict-return', rule, {
         const bar = [1, 2, 3]
         return [...bar]
       }`,
-      parser,
       errors,
     },
     {
@@ -209,35 +180,31 @@ ruleTester.run('react-hooks-strict-return', rule, {
         const baz = [3]
         return [...bar, ...baz];
       }`,
-      parser,
       errors,
     },
     {
       code: `function useFoo() {
         useEffect(() => {});
-      
+
         return [1, 2, 3, 4];
       }`,
-      parser,
       errors,
     },
     {
       code: `function useFoo() {
         useSomeOtherHook();
-      
+
         return [1, 2, 3, 4];
       }`,
-      parser,
       errors,
     },
     {
       code: `function useFoo() {
         useSomeOtherHook();
         useEffect(() => {});
-      
+
         return [1, 2, 3, 4];
       }`,
-      parser,
       errors,
     },
   ],

--- a/tests/lib/rules/react-initialize-state.js
+++ b/tests/lib/rules/react-initialize-state.js
@@ -1,13 +1,11 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/react-initialize-state');
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+});
 
-require('babel-eslint');
-require('typescript-eslint-parser');
-
-const babelParser = 'babel-eslint';
-const typeScriptParser = 'typescript-eslint-parser';
+const typeScriptParser = require.resolve('typescript-eslint-parser');
 
 const errors = [
   {
@@ -20,45 +18,36 @@ ruleTester.run('react-initialize-state', rule, {
   valid: [
     {
       code: 'class Button {}',
-      parser: babelParser,
     },
     {
       code: 'class Button extends Klass {}',
-      parser: babelParser,
     },
     {
       code: 'class Button extends React.Component {}',
-      parser: babelParser,
     },
     {
       code: 'class Button extends React.Component<Props> {}',
-      parser: babelParser,
     },
     {
       code: 'class Button extends React.Component<Props, {}> {}',
-      parser: babelParser,
     },
     {
       code: 'class Button extends React.Component<Props, any> {}',
-      parser: babelParser,
     },
     {
       code: `class Button extends React.Component<Props, {focused: boolean}> {
         state = {focused: false};
       }`,
-      parser: babelParser,
     },
     {
       code: `class Button extends React.Component<Props, State> {
         state = {focused: false};
       }`,
-      parser: babelParser,
     },
     {
       code: `class Button extends React.Component<Props, State> {
         state = getState();
       }`,
-      parser: babelParser,
     },
     {
       code: `class Button extends React.Component<Props, State> {
@@ -66,7 +55,6 @@ ruleTester.run('react-initialize-state', rule, {
           this.state = {focused: true};
         }
       }`,
-      parser: babelParser,
     },
     {
       code: `class Button extends React.Component<Props, State> {
@@ -74,7 +62,6 @@ ruleTester.run('react-initialize-state', rule, {
           this.state = getState();
         }
       }`,
-      parser: babelParser,
     },
     {
       code: `class Button extends React.Component<Props, State> {
@@ -84,7 +71,6 @@ ruleTester.run('react-initialize-state', rule, {
           this.state = {};
         }
       }`,
-      parser: babelParser,
     },
     {
       code: `class Button extends React.Component<Props, State> {
@@ -92,7 +78,6 @@ ruleTester.run('react-initialize-state', rule, {
           (this: any).state = {};
         }
       }`,
-      parser: babelParser,
     },
     {
       code: 'class Button extends React.Component {}',
@@ -157,21 +142,18 @@ ruleTester.run('react-initialize-state', rule, {
     {
       code:
         'class Button extends React.Component<Props, {focused: boolean}> {}',
-      parser: babelParser,
       errors,
     },
     {
       code: `class Button extends React.Component<Props, {focused: boolean}> {
         state = null;
       }`,
-      parser: babelParser,
       errors,
     },
     {
       code: `class Button extends React.Component<Props, State> {
         states = {focused: false};
       }`,
-      parser: babelParser,
       errors,
     },
     {
@@ -180,7 +162,6 @@ ruleTester.run('react-initialize-state', rule, {
           this.state = null;
         }
       }`,
-      parser: babelParser,
       errors,
     },
     {
@@ -189,21 +170,18 @@ ruleTester.run('react-initialize-state', rule, {
           this.states = {focused: true};
         }
       }`,
-      parser: babelParser,
       errors,
     },
     {
       code: `class Button extends React.Component<Props> {
         state: State;
       }`,
-      parser: babelParser,
       errors,
     },
     {
       code: `class Button extends React.Component<Props, State> {
         state: State;
       }`,
-      parser: babelParser,
       errors,
     },
     {
@@ -211,7 +189,6 @@ ruleTester.run('react-initialize-state', rule, {
         state: State;
         constructor() {}
       }`,
-      parser: babelParser,
       errors,
     },
     {
@@ -219,7 +196,6 @@ ruleTester.run('react-initialize-state', rule, {
         class Button extends React.Component<Props, State> {}
         class OtherClass {}
       `,
-      parser: babelParser,
       errors,
     },
     {

--- a/tests/lib/rules/react-no-multiple-render-methods.js
+++ b/tests/lib/rules/react-no-multiple-render-methods.js
@@ -1,11 +1,9 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/react-no-multiple-render-methods');
 
-const ruleTester = new RuleTester();
-
-require('babel-eslint');
-
-const babelParser = 'babel-eslint';
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+});
 
 function error(memberName) {
   return {
@@ -20,14 +18,12 @@ ruleTester.run('react-no-multiple-render-methods', rule, {
       code: `class Button extends React.Component {
         render() {}
       }`,
-      parser: babelParser,
     },
     {
       code: `class Button extends React.Component {
         otherMethod() {}
         render() {}
       }`,
-      parser: babelParser,
     },
   ],
   invalid: [
@@ -35,7 +31,6 @@ ruleTester.run('react-no-multiple-render-methods', rule, {
       code: `class Button extends React.Component {
         renderFoo() {}
       }`,
-      parser: babelParser,
       errors: [error('renderFoo')],
     },
     {
@@ -43,7 +38,6 @@ ruleTester.run('react-no-multiple-render-methods', rule, {
         renderFoo() {}
         render() {}
       }`,
-      parser: babelParser,
       errors: [error('renderFoo')],
     },
     {
@@ -52,7 +46,6 @@ ruleTester.run('react-no-multiple-render-methods', rule, {
         renderBar() {}
         render() {}
       }`,
-      parser: babelParser,
       errors: [error('renderFoo'), error('renderBar')],
     },
   ],

--- a/tests/lib/rules/react-prefer-private-members.js
+++ b/tests/lib/rules/react-prefer-private-members.js
@@ -1,13 +1,11 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/react-prefer-private-members');
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parser: require.resolve('typescript-eslint-parser'),
+});
 
-require('babel-eslint');
-require('typescript-eslint-parser');
-
-const babelParser = 'babel-eslint';
-const typeScriptParser = 'typescript-eslint-parser';
+const babelParser = require.resolve('babel-eslint');
 
 function makeError({type = 'ClassProperty', memberName, componentName}) {
   return {
@@ -23,7 +21,6 @@ ruleTester.run('react-prefer-private-members', rule, {
         private member = true;
         componentDidMount() {}
       }`,
-      parser: typeScriptParser,
     },
     {
       code: `class Button extends Klass {
@@ -113,7 +110,6 @@ ruleTester.run('react-prefer-private-members', rule, {
         alsoInvalid() {}
         render() {}
       }`,
-      parser: typeScriptParser,
       errors: [
         makeError({memberName: 'inValid', componentName: 'Button'}),
         makeError({

--- a/tests/lib/rules/react-type-state.js
+++ b/tests/lib/rules/react-type-state.js
@@ -1,11 +1,9 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../lib/rules/react-type-state');
 
-const ruleTester = new RuleTester();
-
-require('typescript-eslint-parser');
-
-const parser = 'typescript-eslint-parser';
+const ruleTester = new RuleTester({
+  parser: require.resolve('typescript-eslint-parser'),
+});
 
 const errors = [
   {
@@ -19,31 +17,25 @@ ruleTester.run('react-type-state', rule, {
   valid: [
     {
       code: 'class Button {}',
-      parser,
     },
     {
       code: 'class Button<Props, State> {}',
-      parser,
     },
     {
       code: 'class Button extends React.Component<Props, State> {}',
-      parser,
     },
     {
       code: 'class Button extends React.PureComponent<Props, State> {}',
-      parser,
     },
     {
       code: `class Button extends React.Component<Props, State> {
         state: State = {};
       }`,
-      parser,
     },
     {
       code: `class Button extends React.PureComponent<Props, State> {
         state: State = {};
       }`,
-      parser,
     },
   ],
   invalid: [
@@ -52,14 +44,12 @@ ruleTester.run('react-type-state', rule, {
         state = {};
       }`,
       errors,
-      parser,
     },
     {
       code: `class Button extends React.PureComponent<Props, State> {
         state = {};
       }`,
       errors,
-      parser,
     },
   ],
 });

--- a/tests/lib/rules/typescript/prefer-pascal-case-enums.js
+++ b/tests/lib/rules/typescript/prefer-pascal-case-enums.js
@@ -2,11 +2,9 @@ const {RuleTester} = require('eslint');
 
 const rule = require('../../../../lib/rules/typescript/prefer-pascal-case-enums');
 
-const ruleTester = new RuleTester();
-
-require('typescript-eslint-parser');
-
-const typeScriptParser = 'typescript-eslint-parser';
+const ruleTester = new RuleTester({
+  parser: require.resolve('typescript-eslint-parser'),
+});
 
 function errorWithName(name) {
   return {
@@ -19,38 +17,31 @@ ruleTester.run('prefer-pascal-case-enums', rule, {
   valid: [
     {
       code: `enum SortOrder {MostRecent, LeastRecent, Newest, Oldest}`,
-      parser: typeScriptParser,
     },
   ],
   invalid: [
     {
       code: `enum SORTORDER {MostRecent, LeastRecent, Newest, Oldest}`,
-      parser: typeScriptParser,
       errors: [errorWithName('SORTORDER')],
     },
     {
       code: `enum sortorder {MostRecent, LeastRecent, Newest, Oldest}`,
-      parser: typeScriptParser,
       errors: [errorWithName('sortorder')],
     },
     {
       code: `enum sort_order {MostRecent, LeastRecent, Newest, Oldest}`,
-      parser: typeScriptParser,
       errors: [errorWithName('sort_order')],
     },
     {
       code: `enum sortOrder {MostRecent, LeastRecent, Newest, Oldest}`,
-      parser: typeScriptParser,
       errors: [errorWithName('sortOrder')],
     },
     {
       code: `enum sortOrder {mostRecent, LeastRecent, Newest, Oldest}`,
-      parser: typeScriptParser,
       errors: [errorWithName('sortOrder'), errorWithName('mostRecent')],
     },
     {
       code: `enum SortOrder {MOSTRECENT, least_recent, Newest, Oldest}`,
-      parser: typeScriptParser,
       errors: [errorWithName('MOSTRECENT'), errorWithName('least_recent')],
     },
   ],

--- a/tests/lib/rules/typescript/prefer-singular-enums.js
+++ b/tests/lib/rules/typescript/prefer-singular-enums.js
@@ -2,11 +2,9 @@ const {RuleTester} = require('eslint');
 
 const rule = require('../../../../lib/rules/typescript/prefer-singular-enums');
 
-const ruleTester = new RuleTester();
-
-require('typescript-eslint-parser');
-
-const typeScriptParser = 'typescript-eslint-parser';
+const ruleTester = new RuleTester({
+  parser: require.resolve('typescript-eslint-parser'),
+});
 
 function errorWithName(name) {
   return {
@@ -19,47 +17,38 @@ ruleTester.run('prefer-singular-enums', rule, {
   valid: [
     {
       code: `enum SortOrder {MostRecent, LeastRecent, Newest, Oldest}`,
-      parser: typeScriptParser,
     },
     {
       code: `enum Command {Up, Down}`,
-      parser: typeScriptParser,
     },
     {
       code: `enum Page {Products, Orders}`,
-      parser: typeScriptParser,
     },
   ],
   invalid: [
     {
       code: `enum SortOrders {MostRecent, LeastRecent, Newest, Oldest}`,
-      parser: typeScriptParser,
       errors: [errorWithName('SortOrders')],
     },
     {
       code: `enum Commands {Up, Down}`,
-      parser: typeScriptParser,
       errors: [errorWithName('Commands')],
     },
     {
       code: `enum Pages {Products, Orders}`,
-      parser: typeScriptParser,
       errors: [errorWithName('Pages')],
     },
     {
       code: `enum Feet {Left, Right}`,
-      parser: typeScriptParser,
       errors: [errorWithName('Feet')],
     },
 
     {
       code: `enum People {}`,
-      parser: typeScriptParser,
       errors: [errorWithName('People')],
     },
     {
       code: `enum Children {}`,
-      parser: typeScriptParser,
       errors: [errorWithName('Children')],
     },
   ],

--- a/tests/lib/rules/webpack/no-unnamed-dynamic-imports.js
+++ b/tests/lib/rules/webpack/no-unnamed-dynamic-imports.js
@@ -1,91 +1,84 @@
 const {RuleTester} = require('eslint');
 const rule = require('../../../../lib/rules/webpack/no-unnamed-dynamic-imports');
 
-const ruleTester = new RuleTester();
+const ruleTester = new RuleTester({
+  parser: require.resolve('babel-eslint'),
+});
 
 const CHUNK_NAME_REQUIRED =
   'imports should have a webpackChunkName (https://webpack.js.org/api/module-methods/#import-)';
 
-const validExamples = [
-  {
-    code: `
-      function foo() {
-        return import(/* webpackChunkName: "bar" */ 'bar');
-      }
-    `,
-    parser: 'babel-eslint',
-  },
-  {
-    code: `
-      function foo() {
-        return import(/* webpackChunkName: 'bar' */ 'bar');
-      }
-    `,
-    parser: 'babel-eslint',
-  },
-  {
-    code: `
-      async function foo() {
-        await import(/* webpackChunkName: 'bar' */ 'bar');
-      }
-    `,
-    parser: 'babel-eslint',
-  },
-  {
-    code: `System.import(/* webpackChunkName: "bar" */ 'bar');`,
-  },
-  {
-    code: `
-      System.import(
-        /* webpackMode: "lazy" */
-        /* webpackChunkName: "bar" */ 'bar'
-      );
-    `,
-  },
-  {
-    code: `System.imported('foo');`,
-  },
-  {
-    code: `System.other('foo');`,
-  },
-  {
-    code: `
-    async function foo() {
-      return System.import<{default: any}>(
-        /* webpackChunkName: "bar" */ './bar',
-      ).then(bar => bar);
-    }
-    `,
-    parser: 'typescript-eslint-parser',
-  },
-];
-
-const invalidExamples = [
-  {
-    code: `function foo() { import('bar'); }`,
-    options: ['never'],
-    parser: 'babel-eslint',
-    errors: [CHUNK_NAME_REQUIRED],
-  },
-  {
-    code: `function foo() { System.import('bar'); }`,
-    options: ['never'],
-    errors: [CHUNK_NAME_REQUIRED],
-  },
-  {
-    code: `
-      System.import(
-        // webpackChunkName: "bar"
-        'bar'
-      );
-    `,
-    options: ['never'],
-    parser: 'babel-eslint',
-    errors: ['webpackChunkName must be in a /* */ block comment'],
-  },
-];
-
 ruleTester.run('webpack/no-unnamed-dynamic-imports', rule, {
-  valid: validExamples,
-  invalid: invalidExamples,
+  valid: [
+    {
+      code: `
+        function foo() {
+          return import(/* webpackChunkName: "bar" */ 'bar');
+        }
+      `,
+    },
+    {
+      code: `
+        function foo() {
+          return import(/* webpackChunkName: 'bar' */ 'bar');
+        }
+      `,
+    },
+    {
+      code: `
+        async function foo() {
+          await import(/* webpackChunkName: 'bar' */ 'bar');
+        }
+      `,
+    },
+    {
+      code: `System.import(/* webpackChunkName: "bar" */ 'bar');`,
+    },
+    {
+      code: `
+        System.import(
+          /* webpackMode: "lazy" */
+          /* webpackChunkName: "bar" */ 'bar'
+        );
+      `,
+    },
+    {
+      code: `System.imported('foo');`,
+    },
+    {
+      code: `System.other('foo');`,
+    },
+    {
+      code: `
+      async function foo() {
+        return System.import<{default: any}>(
+          /* webpackChunkName: "bar" */ './bar',
+        ).then(bar => bar);
+      }
+      `,
+      parser: require.resolve('typescript-eslint-parser'),
+    },
+  ],
+  invalid: [
+    {
+      code: `function foo() { import('bar'); }`,
+      options: ['never'],
+      errors: [CHUNK_NAME_REQUIRED],
+    },
+    {
+      code: `function foo() { System.import('bar'); }`,
+      options: ['never'],
+      errors: [CHUNK_NAME_REQUIRED],
+    },
+    {
+      code: `
+        System.import(
+          // webpackChunkName: "bar"
+          'bar'
+        );
+      `,
+      options: ['never'],
+      errors: ['webpackChunkName must be in a /* */ block comment'],
+    },
+  ],
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -992,7 +992,7 @@ ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.9.1:
+ajv@^6.10.0, ajv@^6.9.1:
   version "6.10.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.0.tgz#90d0d54439da587cd7e843bfb7045f50bd22bdf1"
   integrity sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==
@@ -1945,13 +1945,13 @@ eslint@4.19.1, eslint@^4.2.0:
     table "4.0.2"
     text-table "~0.2.0"
 
-eslint@^5.16.0:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
-  integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==
+eslint@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.0.1.tgz#4a32181d72cb999d6f54151df7d337131f81cda7"
+  integrity sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    ajv "^6.9.1"
+    ajv "^6.10.0"
     chalk "^2.1.0"
     cross-spawn "^6.0.5"
     debug "^4.0.1"
@@ -1959,18 +1959,19 @@ eslint@^5.16.0:
     eslint-scope "^4.0.3"
     eslint-utils "^1.3.1"
     eslint-visitor-keys "^1.0.0"
-    espree "^5.0.1"
+    espree "^6.0.0"
     esquery "^1.0.1"
     esutils "^2.0.2"
     file-entry-cache "^5.0.1"
     functional-red-black-tree "^1.0.1"
-    glob "^7.1.2"
+    glob-parent "^3.1.0"
     globals "^11.7.0"
     ignore "^4.0.6"
     import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     inquirer "^6.2.2"
-    js-yaml "^3.13.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
     json-stable-stringify-without-jsonify "^1.0.1"
     levn "^0.3.0"
     lodash "^4.17.11"
@@ -1978,7 +1979,6 @@ eslint@^5.16.0:
     mkdirp "^0.5.1"
     natural-compare "^1.4.0"
     optionator "^0.8.2"
-    path-is-inside "^1.0.2"
     progress "^2.0.0"
     regexpp "^2.0.1"
     semver "^5.5.1"
@@ -1995,10 +1995,10 @@ espree@^3.5.4:
     acorn "^5.5.0"
     acorn-jsx "^3.0.0"
 
-espree@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-5.0.1.tgz#5d6526fa4fc7f0788a5cf75b15f30323e2f81f7a"
-  integrity sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==
+espree@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.0.0.tgz#716fc1f5a245ef5b9a7fdb1d7b0d3f02322e75f6"
+  integrity sha512-lJvCS6YbCn3ImT3yKkPe0+tJ+mH6ljhGNjHQH9mRtiO6gjhVAOhVXW1yjnwqGwTkK3bGbye+hb00nFNmu0l/1Q==
   dependencies:
     acorn "^6.0.7"
     acorn-jsx "^5.0.0"
@@ -2247,6 +2247,14 @@ get-stream@^4.0.0:
   integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
   dependencies:
     pump "^3.0.0"
+
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
 
 glob@7.1.3, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
@@ -2540,6 +2548,11 @@ is-date-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
   integrity sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=
 
+is-extglob@^2.1.0, is-extglob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
+  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -2551,6 +2564,20 @@ is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
+  dependencies:
+    is-extglob "^2.1.0"
+
+is-glob@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
+  integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
 
 is-promise@^2.1.0:
   version "2.1.0"
@@ -2636,7 +2663,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.13.1, js-yaml@3.x, js-yaml@^3.10.0, js-yaml@^3.13.0, js-yaml@^3.9.1:
+js-yaml@3.13.1, js-yaml@3.x, js-yaml@^3.10.0, js-yaml@^3.13.1, js-yaml@^3.9.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -3182,6 +3209,11 @@ pascal-case@^2.0.1:
   dependencies:
     camel-case "^3.0.0"
     upper-case-first "^1.1.0"
+
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
 
 path-exists@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Brings us to eslint@6.x. Not having this update is causing some dependabot PRs to fail.

Update tests 'parser' requiring an absolute path rather than a package name. Details found in the [migration guide](https://eslint.org/docs/6.0.0/user-guide/migrating-to-6.0.0#rule-tester-parser). 

>In ESLint v6.0.0, RuleTester disallows parser property with a package name. To address: If you use parser property with package names in test cases, update it with require.resolve() function to resolve the package name to the absolute path to the package.

Without these changes to the tests, these tests expectedly failed due to the parser option not being an absolute path; with the change to the tests, they all pass.

