### PR TITLE
Don't report nested arrow functions in `jest/no-if`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Enabled `typescript/interface-name-prefix` to prevent `I` prefixes in TypeScript interface names
 
 ### Fixed
-- [Patch] Fix `jest/no-if` from falsely reporting if statements inside of arrow functions ([331](https://github.com/Shopify/eslint-plugin-shopify/pull/331))
+- [Patch] Fix `jest/no-if` from falsely reporting if statements inside of functions ([331](https://github.com/Shopify/eslint-plugin-shopify/pull/331))
 
 ## [29.0.2] - 2019-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## Unreleased
 
 ### Changed
-
 - [Major] Updated to eslint v6, enabled `no-console` and enabled `no-async-promise-executor` ([330](https://github.com/Shopify/eslint-plugin-shopify/pull/330))
 - Enabled `typescript/interface-name-prefix` to prevent `I` prefixes in TypeScript interface names
+
+### Fixed
+- [Patch] Fix `jest/no-if` from false-ly reporting if statements inside of arrow functions ([331](https://github.com/Shopify/eslint-plugin-shopify/pull/331))
 
 ## [29.0.2] - 2019-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Enabled `typescript/interface-name-prefix` to prevent `I` prefixes in TypeScript interface names
 
 ### Fixed
-- [Patch] Fix `jest/no-if` from false-ly reporting if statements inside of arrow functions ([331](https://github.com/Shopify/eslint-plugin-shopify/pull/331))
+- [Patch] Fix `jest/no-if` from falsely reporting if statements inside of arrow functions ([331](https://github.com/Shopify/eslint-plugin-shopify/pull/331))
 
 ## [29.0.2] - 2019-06-18
 

--- a/lib/rules/jest/no-if.js
+++ b/lib/rules/jest/no-if.js
@@ -1,5 +1,5 @@
 const {docsUrl} = require('../../utilities');
-const {isTestDefinition} = require('../../utilities/jest');
+const {isTestDefinition, isTestArrowFunction} = require('../../utilities/jest');
 
 module.exports = {
   meta: {
@@ -56,9 +56,15 @@ module.exports = {
       CallExpression(node) {
         stack.push(isTestDefinition(node));
       },
+      ArrowFunctionExpression(node) {
+        stack.push(isTestArrowFunction(node));
+      },
       IfStatement: validate,
       ConditionalExpression: validate,
       'CallExpression:exit': function() {
+        stack.pop();
+      },
+      'ArrowFunctionExpression:exit': function() {
         stack.pop();
       },
     };

--- a/lib/rules/jest/no-if.js
+++ b/lib/rules/jest/no-if.js
@@ -56,12 +56,24 @@ module.exports = {
       CallExpression(node) {
         stack.push(isTestDefinition(node));
       },
+      FunctionExpression() {
+        stack.push(false);
+      },
+      FunctionDeclaration() {
+        stack.push(false);
+      },
       ArrowFunctionExpression(node) {
         stack.push(isTestArrowFunction(node));
       },
       IfStatement: validate,
       ConditionalExpression: validate,
       'CallExpression:exit': function() {
+        stack.pop();
+      },
+      'FunctionExpression:exit': function() {
+        stack.pop();
+      },
+      'FunctionDeclaration:exit': function() {
         stack.pop();
       },
       'ArrowFunctionExpression:exit': function() {

--- a/lib/utilities/jest.js
+++ b/lib/utilities/jest.js
@@ -33,8 +33,17 @@ function isTestDefinition(node) {
   );
 }
 
+function isTestArrowFunction(node) {
+  return (
+    node.type === 'ArrowFunctionExpression' &&
+    node.parent.type === 'CallExpression' &&
+    TEST_DEFINITION_NAMES.includes(getTestMethodName(node.parent))
+  );
+}
+
 module.exports = {
   TEST_FUNCTION_NAMES,
   getTestMethodName,
   isTestDefinition,
+  isTestArrowFunction,
 };

--- a/tests/lib/rules/jest/no-if.js
+++ b/tests/lib/rules/jest/no-if.js
@@ -133,6 +133,42 @@ ruleTester.run('no-if', rule, {
         };
       });`,
     },
+    {
+      code: `it('foo', () => {
+        const foo = function(bar) {
+          return foo ? bar : null;
+        };
+      });`,
+    },
+    {
+      code: `it('foo', () => {
+        const foo = function(bar) {
+          if (bar) {
+            return 1;
+          } else {
+            return 2;
+          }
+        };
+      });`,
+    },
+    {
+      code: `it('foo', () => {
+        function foo(bar) {
+          return foo ? bar : null;
+        };
+      });`,
+    },
+    {
+      code: `it('foo', () => {
+        function foo(bar) {
+          if (bar) {
+            return 1;
+          } else {
+            return 2;
+          }
+        };
+      });`,
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/jest/no-if.js
+++ b/tests/lib/rules/jest/no-if.js
@@ -126,6 +126,13 @@ ruleTester.run('no-if', rule, {
       });
       `,
     },
+    {
+      code: `it('foo', () => {
+        const foo = bar => {
+          return foo ? bar : null;
+        };
+    });`,
+    },
   ],
   invalid: [
     {

--- a/tests/lib/rules/jest/no-if.js
+++ b/tests/lib/rules/jest/no-if.js
@@ -131,7 +131,7 @@ ruleTester.run('no-if', rule, {
         const foo = bar => {
           return foo ? bar : null;
         };
-    });`,
+      });`,
     },
   ],
   invalid: [


### PR DESCRIPTION
Fixes https://github.com/Shopify/eslint-plugin-shopify/issues/311

This PR changes jest/no-if so that it reports on if statements that are nested in arrow functions (all of which would be nested in a test CallExpression). This fix was done in 2 steps:
1) Push ArrowFunctions on to our in-memory stack
2) Store those items as a boolean, true if it is part of the test structure (the second argument to it/test/etc...)

The rest of the logic remained the same. We check to see if the last item pushed was true/false, and report if it is.

In other words, "if we are an if statement and we are just inside an arrow function and that arrow function that we are just inside is part of an it/test/etc... function, then we report it".

I implemented this by adding a new jest utility for checking if an ArrowFunction is part of an it/test/etc... function.

cc @BPScott 