### PR TITLE
Return no-console error

### DIFF
--- a/lib/config/node.js
+++ b/lib/config/node.js
@@ -9,5 +9,6 @@ module.exports = {
 
   rules: merge(require('./rules/node'), {
     'no-process-env': 'off',
+    'no-console': 'off',
   }),
 };

--- a/lib/config/rules/possible-errors.js
+++ b/lib/config/rules/possible-errors.js
@@ -14,7 +14,7 @@ module.exports = {
   // Disallow assignment in conditional expressions
   'no-cond-assign': 'error',
   // Disallow use of console
-  'no-console': 'off',
+  'no-console': 'error',
   // Disallow use of constant expressions in conditions
   'no-constant-condition': ['error', {checkLoops: false}],
   // Disallow control characters in regular expressions


### PR DESCRIPTION
In the eslint v6 migration I turned this off thinking we likely disable it in all our CLIs, and folks should just enable it in their project if needed. But it is better to just use our config hierarchy to achieve this.

This PR re-enabled no-console in the base config and disables it in node only.