### PR TITLE
Bump Eslint peer dependency again

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "typescript": "~3.1.1"
   },
   "peerDependencies": {
-    "eslint": ">=5",
+    "eslint": ">=6",
     "prettier": "^1.14.0"
   },
   "dependencies": {


### PR DESCRIPTION
This PR fixes a mistake and brings the peer dependency to v6.0.0 to bring in the definitions for the new rules.