### PR TITLE
Enforce new lines between import groups

### DIFF
--- a/lib/config/rules/import.js
+++ b/lib/config/rules/import.js
@@ -95,6 +95,7 @@ module.exports = {
     'error',
     {
       groups: ['builtin', 'external', 'internal', 'parent', 'sibling'],
+      'newlines-between': 'always',
     },
   ],
   // Enforce a newline after import statements

--- a/lib/rules/images-no-direct-imports.js
+++ b/lib/rules/images-no-direct-imports.js
@@ -1,5 +1,7 @@
 const {basename, dirname, extname} = require('path');
+
 const resolve = require('eslint-module-utils/resolve').default;
+
 const {docsUrl} = require('../utilities');
 
 function isImageImport(filename) {

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -1,4 +1,5 @@
 const commonTags = require('common-tags');
+
 const {docsUrl} = require('../../utilities');
 const {
   TEST_FUNCTION_NAMES,

--- a/lib/rules/no-ancestor-directory-import.js
+++ b/lib/rules/no-ancestor-directory-import.js
@@ -1,5 +1,7 @@
 const {extname, basename, relative, sep} = require('path');
+
 const resolve = require('eslint-module-utils/resolve').default;
+
 const {docsUrl} = require('../utilities');
 
 module.exports = {

--- a/lib/rules/react-initialize-state.js
+++ b/lib/rules/react-initialize-state.js
@@ -1,4 +1,5 @@
 const Components = require('eslint-plugin-react/lib/util/Components');
+
 const {docsUrl, uncast, getName} = require('../utilities');
 
 module.exports = {

--- a/lib/rules/react-no-multiple-render-methods.js
+++ b/lib/rules/react-no-multiple-render-methods.js
@@ -1,4 +1,5 @@
 const Components = require('eslint-plugin-react/lib/util/Components');
+
 const {docsUrl} = require('../utilities');
 
 const message = [

--- a/lib/rules/react-prefer-private-members.js
+++ b/lib/rules/react-prefer-private-members.js
@@ -1,5 +1,6 @@
 const pascalCase = require('pascal-case');
 const Components = require('eslint-plugin-react/lib/util/Components');
+
 const {docsUrl} = require('../utilities');
 
 module.exports = {

--- a/lib/rules/react-type-state.js
+++ b/lib/rules/react-type-state.js
@@ -1,4 +1,5 @@
 const Components = require('eslint-plugin-react/lib/util/Components');
+
 const {docsUrl, getName} = require('../utilities');
 
 module.exports = {

--- a/lib/rules/strict-component-boundaries.js
+++ b/lib/rules/strict-component-boundaries.js
@@ -1,6 +1,8 @@
 const {basename, extname, relative} = require('path');
+
 const pascalCase = require('pascal-case');
 const resolve = require('eslint-module-utils/resolve').default;
+
 const {docsUrl} = require('../utilities');
 
 module.exports = {

--- a/lib/rules/typescript/prefer-pascal-case-enums.js
+++ b/lib/rules/typescript/prefer-pascal-case-enums.js
@@ -1,4 +1,5 @@
 const pascalCase = require('pascal-case');
+
 const {docsUrl} = require('../../utilities');
 
 module.exports = {

--- a/lib/rules/typescript/prefer-singular-enums.js
+++ b/lib/rules/typescript/prefer-singular-enums.js
@@ -1,4 +1,5 @@
 const pluralize = require('pluralize');
+
 const {docsUrl} = require('../../utilities');
 
 module.exports = {

--- a/lib/utilities/index.js
+++ b/lib/utilities/index.js
@@ -1,4 +1,5 @@
 const {join, dirname, relative, basename} = require('path');
+
 const resolve = require('eslint-module-utils/resolve').default;
 const pkgDir = require('pkg-dir');
 

--- a/tests/lib/rules/binary-assignment-parens.test.js
+++ b/tests/lib/rules/binary-assignment-parens.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/binary-assignment-parens');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/class-property-semi.test.js
+++ b/tests/lib/rules/class-property-semi.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/class-property-semi');
 
 const ruleTester = new RuleTester({

--- a/tests/lib/rules/images-no-direct-imports.test.js
+++ b/tests/lib/rules/images-no-direct-imports.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/images-no-direct-imports');
 

--- a/tests/lib/rules/jest/no-snapshots.test.js
+++ b/tests/lib/rules/jest/no-snapshots.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../../lib/rules/jest/no-snapshots');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/jest/no-vague-titles.test.js
+++ b/tests/lib/rules/jest/no-vague-titles.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../../lib/rules/jest/no-vague-titles');
 
 const ruleTester = new RuleTester({parser: require.resolve('babel-eslint')});

--- a/tests/lib/rules/jsx-no-complex-expressions.test.js
+++ b/tests/lib/rules/jsx-no-complex-expressions.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/jsx-no-complex-expressions');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/jsx-no-hardcoded-content.test.js
+++ b/tests/lib/rules/jsx-no-hardcoded-content.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/jsx-no-hardcoded-content');
 

--- a/tests/lib/rules/jsx-prefer-fragment-wrappers.test.js
+++ b/tests/lib/rules/jsx-prefer-fragment-wrappers.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/jsx-prefer-fragment-wrappers');
 
 const ruleTester = new RuleTester({parser: require.resolve('babel-eslint')});

--- a/tests/lib/rules/no-ancestor-directory-import.test.js
+++ b/tests/lib/rules/no-ancestor-directory-import.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/no-ancestor-directory-import');
 

--- a/tests/lib/rules/no-fully-static-classes.test.js
+++ b/tests/lib/rules/no-fully-static-classes.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/no-fully-static-classes');
 
 const ruleTester = new RuleTester({parser: require.resolve('babel-eslint')});

--- a/tests/lib/rules/no-useless-computed-properties.test.js
+++ b/tests/lib/rules/no-useless-computed-properties.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/no-useless-computed-properties');
 
 const ruleTester = new RuleTester({

--- a/tests/lib/rules/polaris-no-bare-stack-item.test.js
+++ b/tests/lib/rules/polaris-no-bare-stack-item.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/polaris-no-bare-stack-item');
 

--- a/tests/lib/rules/polaris-prefer-sectioned-prop.test.js
+++ b/tests/lib/rules/polaris-prefer-sectioned-prop.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/polaris-prefer-sectioned-prop');
 

--- a/tests/lib/rules/prefer-class-properties.test.js
+++ b/tests/lib/rules/prefer-class-properties.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/prefer-class-properties');
 
 const ruleTester = new RuleTester({

--- a/tests/lib/rules/prefer-early-return.test.js
+++ b/tests/lib/rules/prefer-early-return.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/prefer-early-return');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/prefer-module-scope-constants.test.js
+++ b/tests/lib/rules/prefer-module-scope-constants.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/prefer-module-scope-constants');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/prefer-twine.test.js
+++ b/tests/lib/rules/prefer-twine.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/prefer-twine');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/react-hooks-strict-return.test.js
+++ b/tests/lib/rules/react-hooks-strict-return.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/react-hooks-strict-return');
 
 const ruleTester = new RuleTester({parser: require.resolve('babel-eslint')});

--- a/tests/lib/rules/react-initialize-state.test.js
+++ b/tests/lib/rules/react-initialize-state.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/react-initialize-state');
 
 const ruleTester = new RuleTester({

--- a/tests/lib/rules/react-no-multiple-render-methods.test.js
+++ b/tests/lib/rules/react-no-multiple-render-methods.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/react-no-multiple-render-methods');
 
 const ruleTester = new RuleTester({

--- a/tests/lib/rules/react-prefer-private-members.test.js
+++ b/tests/lib/rules/react-prefer-private-members.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/react-prefer-private-members');
 
 const ruleTester = new RuleTester({

--- a/tests/lib/rules/react-type-state.test.js
+++ b/tests/lib/rules/react-type-state.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/react-type-state');
 
 const ruleTester = new RuleTester({

--- a/tests/lib/rules/restrict-full-import.test.js
+++ b/tests/lib/rules/restrict-full-import.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/restrict-full-import');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/sinon-no-restricted-features.test.js
+++ b/tests/lib/rules/sinon-no-restricted-features.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/sinon-no-restricted-features');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/sinon-prefer-meaningful-assertions.test.js
+++ b/tests/lib/rules/sinon-prefer-meaningful-assertions.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../lib/rules/sinon-prefer-meaningful-assertions');
 
 const ruleTester = new RuleTester();

--- a/tests/lib/rules/strict-component-boundaries.test.js
+++ b/tests/lib/rules/strict-component-boundaries.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const {fixtureFile} = require('../../utilities');
 const rule = require('../../../lib/rules/strict-component-boundaries');
 

--- a/tests/lib/rules/webpack/no-unnamed-dynamic-imports.test.js
+++ b/tests/lib/rules/webpack/no-unnamed-dynamic-imports.test.js
@@ -1,4 +1,5 @@
 const {RuleTester} = require('eslint');
+
 const rule = require('../../../../lib/rules/webpack/no-unnamed-dynamic-imports');
 
 const ruleTester = new RuleTester({


### PR DESCRIPTION
This enforces a new line between import groups, from this rule: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/order.md#newlines-between-ignorealwaysalways-and-inside-groupsnever

The reason I chose this approach is because it enforces what looks to be the side our codebase leans towards:

The effect of running with `always` (caps at 999)
![https://screenshot.click/16-45-j6ozp-g0ol1.jpg](https://screenshot.click/16-45-j6ozp-g0ol1.jpg)

The effect of running with `never`
![https://screenshot.click/16-48-r23ln-jt4u0.jpg](https://screenshot.click/16-48-r23ln-jt4u0.jpg)

With the addition of this rule the following are true:

**Invalid**

```js
import fs from 'fs';
import path from 'path';
import index from './';
import sibling from './foo';
```

**Valid**
```js
import fs from 'fs';
import path from 'path';

import index from './';

import sibling from './foo';
```

I attempted to see what this rule would cause if I also ran `--fix` on web, and this was the result: 
https://github.com/Shopify/web/pull/18382