### PR TITLE
Use Overrides in GraphQL Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+- **Breaking Change** the `graphql` configs have been pushed to an `override` for files matching a `.graphql` extension. This will allow this config to chain together with other parser-setting configs without changing the parser value.
+
+**Before this change**
+
+```
+// .eslintrc
+// Final parser becomes `babel-eslint` for all files.
+// This will cause errors when parsing TypeScript files
+// even though we are extending the typescript config :(
+{
+  extends: [
+    "plugin:shopify/typescript",
+    "plugin:shopify/graphql"
+  ]
+}
+
+```
+
+**After this change**
+
+```
+// .eslintrc
+// Final parser is `babel-eslint` for only `.graphql` files
+// while `@typescript-eslint/parser` is set for all `.ts`
+// and `.tsx` files. This should not cause any parser-related
+// errors :)
+{
+  extends: [
+    "plugin:shopify/typescript",
+    "plugin:shopify/graphql"
+  ]
+}
+
+```
+
 ## Unreleased
 
 ### New Rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-- **Breaking Change** the `graphql` configs have been pushed to an `override` for files matching a `.graphql` extension. This will allow this config to chain together with other parser-setting configs without changing the parser value. Consider the following config:
+## Unreleased
+
+### Breaking Change
+
+- The `graphql` configs have been pushed to an `override` for files matching a `.graphql` extension. This will allow this config to chain together with other parser-setting configs without changing the parser value. Consider the following config:
 
 ```
 // .eslintrc
@@ -15,8 +19,6 @@
 **Before this change** the final parser becomes `babel-eslint` for all files. This will cause errors when parsing TypeScript files even though we are extending the typescript config :( You could workaround this by moving the `plugin:shopify/graphql` first in the extends array or lint GraphQL files in a seperate script.
 
 **After this change** Final parser is `babel-eslint` for only `.graphql` files while `@typescript-eslint/parser` is set for all `.ts` and `.tsx` files. This should not cause any parser-related errors :)
-
-## Unreleased
 
 ### New Rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,20 @@
 # Changelog
 
-- **Breaking Change** the `graphql` configs have been pushed to an `override` for files matching a `.graphql` extension. This will allow this config to chain together with other parser-setting configs without changing the parser value.
-
-**Before this change**
+- **Breaking Change** the `graphql` configs have been pushed to an `override` for files matching a `.graphql` extension. This will allow this config to chain together with other parser-setting configs without changing the parser value. Consider the following config:
 
 ```
 // .eslintrc
-// Final parser becomes `babel-eslint` for all files.
-// This will cause errors when parsing TypeScript files
-// even though we are extending the typescript config :(
 {
   extends: [
     "plugin:shopify/typescript",
     "plugin:shopify/graphql"
   ]
 }
-
 ```
 
-**After this change**
+**Before this change** the final parser becomes `babel-eslint` for all files. This will cause errors when parsing TypeScript files even though we are extending the typescript config :( You could workaround this by moving the `plugin:shopify/graphql` first in the extends array or lint GraphQL files in a seperate script.
 
-```
-// .eslintrc
-// Final parser is `babel-eslint` for only `.graphql` files
-// while `@typescript-eslint/parser` is set for all `.ts`
-// and `.tsx` files. This should not cause any parser-related
-// errors :)
-{
-  extends: [
-    "plugin:shopify/typescript",
-    "plugin:shopify/graphql"
-  ]
-}
-
-```
+**After this change** Final parser is `babel-eslint` for only `.graphql` files while `@typescript-eslint/parser` is set for all `.ts` and `.tsx` files. This should not cause any parser-related errors :)
 
 ## Unreleased
 

--- a/lib/config/graphql.js
+++ b/lib/config/graphql.js
@@ -1,7 +1,11 @@
 module.exports = {
-  parser: 'babel-eslint',
-
   plugins: ['graphql'],
 
-  rules: require('./rules/graphql'),
+  overrides: [
+    {
+      parser: 'babel-eslint',
+      files: ['.graphql'],
+      rules: require('./rules/graphql'),
+    },
+  ],
 };

--- a/lib/config/graphql.js
+++ b/lib/config/graphql.js
@@ -4,7 +4,7 @@ module.exports = {
   overrides: [
     {
       parser: 'babel-eslint',
-      files: ['.graphql'],
+      files: ['*.graphql'],
       rules: require('./rules/graphql'),
     },
   ],


### PR DESCRIPTION
Look at the `Changelog.md` for a description of the changes.

One downside to this change is that I think it makes the ability to check `gql` template literals impossible. IMO this is not a problem because we don't consider those a best practise, but maybe this is too autocratic? 🤷‍♂ 