### PR TITLE
Add `maxWorkers` flag to `yarn test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint . --max-warnings 0 --format codeframe",
     "prettier": "eslint --format codeframe . --fix",
     "prettier-check": "eslint --print-config ./lib/config/prettier.js | eslint-config-prettier-check",
-    "test": "jest"
+    "test": "jest --maxWorkers=2"
   },
   "license": "MIT",
   "babel": {


### PR DESCRIPTION
This repo keeps getting out of memory issues. Such as the one below:

https://circleci.com/gh/Shopify/eslint-plugin-shopify/1495?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

I've tested this config change with the builds in this branch https://circleci.com/gh/Shopify/eslint-plugin-shopify/1496 and it solves this problem consistency.