### PR TITLE
Use word boundaries for vague terms separation

### DIFF
--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -7,14 +7,15 @@ const {
 } = require('../../utilities/jest');
 
 const VAGUE_TERMS = {
-  should: /should/i,
-  correct: /correct/i,
-  appropriate: /appropriate/i,
+  correct: /\b(in)?correct(ly)?\b/i,
+  appropriate: /\b(in)?appropriate(ly)?\b/i,
+  properly: /\b(in)?proper(ly)?\b/i,
+  necessary: /\b(un)?necessary(ly)?\b/i,
+
+  descriptive: /\bdescriptive\b/i,
+  should: /\bshould\b/i,
   all: /\ball\b/i,
-  properly: /properly/i,
-  every: /every/i,
-  descriptive: /descriptive/i,
-  necessary: /necessary/i,
+  every: /\bevery\b/i,
 };
 
 module.exports = {

--- a/tests/lib/rules/jest/no-vague-titles.test.js
+++ b/tests/lib/rules/jest/no-vague-titles.test.js
@@ -70,6 +70,30 @@ ruleTester.run('no-vague-titles', rule, {
       code: `someFunction('appropriately')`,
     },
     {
+      code: `someFunction('proper')`,
+    },
+    {
+      code: `someFunction('inproper')`,
+    },
+    {
+      code: `someFunction('Proper')`,
+    },
+    {
+      code: `someFunction('properly')`,
+    },
+    {
+      code: `someFunction('necessary')`,
+    },
+    {
+      code: `someFunction('unnecessary')`,
+    },
+    {
+      code: `someFunction('Necessary')`,
+    },
+    {
+      code: `someFunction('necessaryly')`,
+    },
+    {
       code: `someFunction.only('correct')`,
     },
     {


### PR DESCRIPTION
### Problem
The `no-vague-titles` rule on test statements is perhaps too general. 
For most keywords, the rule matches sequences instead of words.
### Example
If I use a variable that contains a blacklisted word like `someVariableWithEveryInIt` in my title , I get a `no-vague-titles` error because of **every**, even though I technically did not use the word **every** in my title.
### Fix
Change the regular expressions to match words instead of sequences.
Instead of checking if the test statement contains a **sequence**, use [regex's word boundaries](https://www.regular-expressions.info/wordboundaries.html) to check if the string contains a **word**.
>Similar to the way **all** is configured, only difference is the optional prefix/suffix.