### PR TITLE
Fix typos and whitelist keyword `everything`

### DIFF
--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -9,13 +9,14 @@ const {
 const VAGUE_TERMS = {
   correct: /\b(in)?correct(ly)?\b/i,
   appropriate: /\b(in)?appropriate(ly)?\b/i,
-  properly: /\b(in)?proper(ly)?\b/i,
+  properly: /\b(im)?proper(ly)?\b/i,
   necessary: /\b(un)?necessary(ly)?\b/i,
 
   descriptive: /\bdescriptive\b/i,
   should: /\bshould\b/i,
   all: /\ball\b/i,
   every: /\bevery\b/i,
+  everything: /\beverything\b/i,
 };
 
 module.exports = {

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -15,8 +15,7 @@ const VAGUE_TERMS = {
   descriptive: /\bdescriptive\b/i,
   should: /\bshould\b/i,
   all: /\ball\b/i,
-  every: /\bevery\b/i,
-  everything: /\beverything\b/i,
+  every: /\bevery(thing)?\b/i,
 };
 
 module.exports = {

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -10,8 +10,7 @@ const VAGUE_TERMS = {
   correct: /\b(in)?correct(ly)?\b/i,
   appropriate: /\b(in)?appropriate(ly)?\b/i,
   properly: /\b(im)?proper(ly)?\b/i,
-  necessary: /\b(un)?necessary\b/i,
-  necessarily: /\b(un)?necessarily\b/i,
+  necessary: /\b(un)?necessar(y|ily)\b/i,
 
   descriptive: /\bdescriptive\b/i,
   should: /\bshould\b/i,

--- a/lib/rules/jest/no-vague-titles.js
+++ b/lib/rules/jest/no-vague-titles.js
@@ -10,7 +10,8 @@ const VAGUE_TERMS = {
   correct: /\b(in)?correct(ly)?\b/i,
   appropriate: /\b(in)?appropriate(ly)?\b/i,
   properly: /\b(im)?proper(ly)?\b/i,
-  necessary: /\b(un)?necessary(ly)?\b/i,
+  necessary: /\b(un)?necessary\b/i,
+  necessarily: /\b(un)?necessarily\b/i,
 
   descriptive: /\bdescriptive\b/i,
   should: /\bshould\b/i,

--- a/tests/lib/rules/jest/no-vague-titles.test.js
+++ b/tests/lib/rules/jest/no-vague-titles.test.js
@@ -91,7 +91,7 @@ ruleTester.run('no-vague-titles', rule, {
       code: `someFunction('Necessary')`,
     },
     {
-      code: `someFunction('necessaryly')`,
+      code: `someFunction('necessarily')`,
     },
     {
       code: `someFunction.only('correct')`,

--- a/tests/lib/rules/jest/no-vague-titles.test.js
+++ b/tests/lib/rules/jest/no-vague-titles.test.js
@@ -155,6 +155,38 @@ ruleTester.run('no-vague-titles', rule, {
       ],
     },
     {
+      code: "describe('necessarily')",
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "describe('unnecessarily')",
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "test('necessarily')",
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "test('unnecessarily')",
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
       code: "test('necessary')",
       errors: [
         {
@@ -180,6 +212,22 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('properly')",
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "it('improperly')",
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "describe('proper')",
       errors: [
         {
           messageId: 'containsVagueWord',
@@ -630,6 +678,22 @@ ruleTester.run('no-vague-titles', rule, {
       ],
     },
     {
+      code: "describe('inappropriate')",
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "describe('inappropriately')",
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
       code: "it('appropriate')",
       errors: [
         {
@@ -655,6 +719,14 @@ ruleTester.run('no-vague-titles', rule, {
     },
     {
       code: "it('Appropriate')",
+      errors: [
+        {
+          messageId: 'containsVagueWord',
+        },
+      ],
+    },
+    {
+      code: "it('Appropriately')",
       errors: [
         {
           messageId: 'containsVagueWord',


### PR DESCRIPTION
Following up on https://github.com/Shopify/eslint-plugin-shopify/pull/514, fixing a typo and whitelisting the keyword `everything`, which we deem to also be vague in a test title. This keyword was previously being matched by the `every` regex, so this shouldn't raise any new errors