### PR TITLE
[typescript/prefer-pascal-case-enum] Fix an issue with undefined name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 - remove `no-vague-titles` because the rule was adopted into `eslint-plugin-jest`'s `valid-title` rule. See [the `valid-title` documentation](https://github.com/jest-community/eslint-plugin-jest/blob/master/docs/rules/valid-title.md#disallowedwords)
+- Fixed an issue with `typescript/prefer-pascal-case-enum` when you had enum with key as string. ([517](https://github.com/Shopify/eslint-plugin-shopify/pull/517))
 
 ## [34.0.1] - 2019-01-13
 

--- a/lib/rules/typescript/prefer-pascal-case-enums.js
+++ b/lib/rules/typescript/prefer-pascal-case-enums.js
@@ -14,12 +14,12 @@ module.exports = {
   },
   create(context) {
     function report(node) {
-      const {name} = node;
-
+      const {name, value} = node;
+      const identifier = name || value;
       context.report({
         node,
-        message: `Enum '{{name}}' should use Pascal case.`,
-        data: {name},
+        message: `Enum '{{identifier}}' should use Pascal case.`,
+        data: {identifier},
       });
     }
 
@@ -38,6 +38,7 @@ module.exports = {
   },
 };
 
-function isPascalCase({name}) {
-  return name === pascalCase(name);
+function isPascalCase({name, value}) {
+  const identifier = name || value;
+  return identifier != null && identifier === pascalCase(identifier);
 }

--- a/tests/lib/rules/typescript/prefer-pascal-case-enums.test.js
+++ b/tests/lib/rules/typescript/prefer-pascal-case-enums.test.js
@@ -8,7 +8,6 @@ const ruleTester = new RuleTester({
 
 function errorWithName(name) {
   return {
-    type: 'Identifier',
     message: `Enum '${name}' should use Pascal case.`,
   };
 }
@@ -43,6 +42,10 @@ ruleTester.run('prefer-pascal-case-enums', rule, {
     {
       code: `enum SortOrder {MOSTRECENT, least_recent, Newest, Oldest}`,
       errors: [errorWithName('MOSTRECENT'), errorWithName('least_recent')],
+    },
+    {
+      code: `enum Example {'foo' = 'bar', '1024x1024' = '1024x1024', Oldest}`,
+      errors: [errorWithName('foo')],
     },
   ],
 });


### PR DESCRIPTION
Fix: #516

1. We use the node `value` when the `name` is `undefined`. When the key of the enum is declared as a string, the `name` is `undefined`
2. We check if the identifier is defined before we pass the value to the `pascalCase` function.

You can find more context in the issue.