### PR TITLE
Add graphql env option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [34.0.1] - 2019-01-13
+
+- fix enabled graphql rules by specifying `env: 'literal'` ([514](https://github.com/Shopify/eslint-plugin-shopify/pull/518))
+
 ## [34.0.0] - 2019-01-13
 
 - changed `no-vague-titles` rule to catch blacklisted **words** (instead of **sequences**) in the title ([514](https://github.com/Shopify/eslint-plugin-shopify/pull/514))

--- a/lib/config/rules/graphql.js
+++ b/lib/config/rules/graphql.js
@@ -1,8 +1,8 @@
 // uses graphql-config for schema mapping
 module.exports = {
   'graphql/capitalized-type-name': 'off',
-  'graphql/named-operations': 'error',
-  'graphql/no-deprecated-fields': 'error',
+  'graphql/named-operations': ['error', {env: 'literal'}],
+  'graphql/no-deprecated-fields': ['error', {env: 'literal'}],
   'graphql/template-strings': ['error', {env: 'literal'}],
   'graphql/required-fields': 'off',
 };


### PR DESCRIPTION
GraphQL lint rules were not working without the env configuration. I was able to confirm this fix works for multiple schemas defined in a `graphqlconfig` file.