### PR TITLE
Fix error that appears when renaming a function

### DIFF
--- a/lib/rules/react-hooks-strict-return.js
+++ b/lib/rules/react-hooks-strict-return.js
@@ -114,6 +114,10 @@ function getProps(node, scope) {
 }
 
 function isHook(node) {
+  if (!node.id) {
+    return false;
+  }
+
   return /^use[A-Z0-9].*$/.test(node.id.name);
 }
 


### PR DESCRIPTION
In VSC, I have ESLint automatically lint while typing. If I rename a function, and my code appears like this: `function ()` because I'm renaming a function, this error appears:

```
[Error - 2:41:19 p.m.] ESLint stack trace:
[Error - 2:41:19 p.m.] TypeError: Cannot read property 'name' of null
Occurred while linting /config.tsx:5
    at isHook (/node_modules/eslint-plugin-shopify/lib/rules/react-hooks-strict-return.js:117:41)
    at FunctionDeclaration (/node_modules/eslint-plugin-shopify/lib/rules/react-hooks-strict-return.js:38:14)
    at /node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/node_modules/eslint/lib/linter/node-event-generator.js:254:26)
    at NodeEventGenerator.applySelectors (/node_modules/eslint/lib/linter/node-event-generator.js:283:22)
    at NodeEventGenerator.enterNode (/node_modules/eslint/lib/linter/node-event-generator.js:297:14)
    at CodePathAnalyzer.enterNode (/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:634:23)
    at /node_modules/eslint/lib/linter/linter.js:936:32
```

So I'm trying to fix that.

I tried to add a test for this, too, but it wouldn't work, since `function ()` would just throw an error with an unexpected token.