### PR TITLE
Remove old rules on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,6 @@ This plugin provides the following custom rules, which are included as appropria
 - [prefer-class-properties](docs/rules/prefer-class-properties.md): Prefer class properties to assignment of literals in constructors.
 - [prefer-early-return](docs/rules/prefer-early-return.md): Prefer early returns over full-body conditional wrapping in function declarations.
 - [no-ancestor-directory-import](docs/rules/no-ancestor-directory-import.md): Prefer imports from within a directory extend to the file from where they are importing without relying on an index file.
-- [no-all-mocks-methods](docs/rules/no-all-mocks-methods.md): Disallows jest allMocks methods.
 - [prefer-module-scope-constants](docs/rules/prefer-module-scope-constants.md): Prefer that screaming snake case variables always be defined using `const`, and always appear at module scope.
 - [prefer-twine](docs/rules/prefer-twine.md): Prefer Twine over Bindings as the name for twine imports.
 - [react-hooks-strict-return](docs/rules/react-hooks-strict-return.md): Restrict the number of returned items from React hooks.

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ This plugin provides the following custom rules, which are included as appropria
 - [class-property-semi](docs/rules/class-property-semi.md): Require (or disallow) semicolons for class properties.
 - [images-no-direct-imports](docs/rules/images-no-direct-imports.md): Prevent images from being directly imported.
 - [jest/no-snapshots](docs/rules/jest/no-snapshots.md): Disallows jest snapshots.
-- [jest/no-vague-titles](docs/rules/jest/no-vague-titles.md): Prevent the usage of vague words in test statements.
 - [jsx-no-complex-expressions](docs/rules/jsx-no-complex-expressions.md): Disallow complex expressions embedded in in JSX.
 - [jsx-no-hardcoded-content](docs/rules/jsx-no-hardcoded-content.md): Disallow hardcoded content in JSX.
 - [jsx-prefer-fragment-wrappers](docs/rules/jsx-prefer-fragment-wrappers.md): Disallow useless wrapping elements in favour of fragment shorthand in JSX.


### PR DESCRIPTION
This PR remove old rules on readme, such as [no-vague-title](https://github.com/Shopify/eslint-plugin-shopify/pull/519)

@cartogram 